### PR TITLE
fix: use Vite base URL for API and worker

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -9,12 +9,12 @@ if (!rootElement) {
 }
 
 // Start the Mock Service Worker
-// When deploying to a sub-path (like GitHub Pages), we need to provide the explicit URL to the worker script.
-// MSW defaults to looking for it at the root, which causes it to fail in this configuration.
+// Use the app's base URL so the worker script loads correctly in dev and production.
+const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
 worker.start({
   onUnhandledRequest: 'bypass', // Pass through any requests that are not handled by our mock server
   serviceWorker: {
-    url: '/The-Scrum-Book/mockServiceWorker.js'
+    url: `${baseUrl}/mockServiceWorker.js`
   }
 });
 

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,7 +1,7 @@
 import type { Match, LeagueStanding } from "../types";
 
-// The base path is hardcoded to ensure consistency across environments.
-export const API_PREFIX = '/The-Scrum-Book';
+// Use Vite's BASE_URL so fetch requests work in both dev and production builds.
+export const API_PREFIX = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 const handleResponse = async (response: Response) => {
     if (!response.ok) {
@@ -25,4 +25,5 @@ export const fetchMatches = async (): Promise<Match[]> => {
 export const fetchLeagueTable = async (): Promise<LeagueStanding[]> => {
     const response = await fetch(`${API_PREFIX}/api/league-table`);
     return handleResponse(response);
-}
+};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "jsx": "react-jsx"
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "vite.config.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- derive API base path from Vite's `BASE_URL`
- load mock service worker relative to app base path
- strip trailing slashes from `BASE_URL` so requests don't use `//`

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd45f2686c832c81b35b639ca2ede9