### PR TITLE
Load Google GenAI from CDN to restore AI chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ View your app in AI Studio: https://ai.studio/apps/drive/1mmCUM4xZO2InKjNdmmo-2l
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set `VITE_GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+The Google GenAI SDK is fetched from a CDN at runtime, so no extra package installation is required.

--- a/components/AIChatView.tsx
+++ b/components/AIChatView.tsx
@@ -22,7 +22,7 @@ export const AIChatView: React.FC = () => {
 
     useEffect(() => {
         try {
-            const ai = new GoogleGenAI({ apiKey: process.env.API_KEY as string });
+            const ai = new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY });
             chatRef.current = ai.chats.create({
                 model: 'gemini-2.5-flash',
                 config: {

--- a/google-genai.d.ts
+++ b/google-genai.d.ts
@@ -1,0 +1,12 @@
+declare module '@google/genai' {
+  export class GoogleGenAI {
+    constructor(config: { apiKey: string });
+    chats: {
+      create(options: any): Chat;
+    };
+  }
+
+  export interface Chat {
+    sendMessageStream(options: { message: string }): AsyncIterable<{ text: string }>;
+  }
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -12,6 +12,7 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
   readonly VITE_FIREBASE_MEASUREMENT_ID: string;
+  readonly VITE_GEMINI_API_KEY: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,12 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   base: '/The-Scrum-Book/',
+  optimizeDeps: {
+    exclude: ['@google/genai'],
+  },
+  build: {
+    rollupOptions: {
+      external: ['@google/genai'],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Remove `@google/genai` NPM dependency
- Declare module typings for the CDN-delivered SDK
- Exclude `@google/genai` from Vite bundling so the app can run
- Document that the SDK is fetched from a CDN at runtime

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1699b14b8832cacc34a5389e700f3