### PR TITLE
Refine match listings and clean up config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -96,28 +96,30 @@ const App: React.FC = () => {
 
     switch (view) {
       case 'UPCOMING':
-        return <MatchList 
-                  matches={matches}
-                  setMatches={setMatches}
-                  attendedMatchIds={attendedMatchIds}
-                  onAttend={handleAttend} 
-                  onUnattend={handleUnattend}
-                  onRefresh={loadAppData}
-                />;
+        return (
+          <MatchList
+            matches={matches}
+            attendedMatchIds={attendedMatchIds}
+            onAttend={handleAttend}
+            onRefresh={loadAppData}
+          />
+        );
       case 'NEARBY':
-        return <NearbyMatchesView
-                  matches={matches}
-                  attendedMatchIds={attendedMatchIds}
-                  onAttend={handleAttend}
-                  onUnattend={handleUnattend}
-                />;
+        return (
+          <NearbyMatchesView
+            matches={matches}
+            attendedMatchIds={attendedMatchIds}
+            onAttend={handleAttend}
+          />
+        );
       case 'MATCH_DAY':
-        return <MatchdayView 
-                  matches={matches}
-                  attendedMatchIds={attendedMatchIds}
-                  onAttend={handleAttend} 
-                  onUnattend={handleUnattend}
-                />;
+        return (
+          <MatchdayView
+            matches={matches}
+            attendedMatchIds={attendedMatchIds}
+            onAttend={handleAttend}
+          />
+        );
       case 'LEAGUE_TABLE':
         return <LeagueTableView />;
       case 'TEAM_STATS':
@@ -155,14 +157,14 @@ const App: React.FC = () => {
       case 'ADMIN':
         return <DataUploader />;
       default:
-        return <MatchList 
-                  matches={matches} 
-                  setMatches={setMatches}
-                  attendedMatchIds={attendedMatchIds}
-                  onAttend={handleAttend}
-                  onUnattend={handleUnattend}
-                  onRefresh={loadAppData}
-                />;
+        return (
+          <MatchList
+            matches={matches}
+            attendedMatchIds={attendedMatchIds}
+            onAttend={handleAttend}
+            onRefresh={loadAppData}
+          />
+        );
     }
   };
 

--- a/components/MatchList.tsx
+++ b/components/MatchList.tsx
@@ -1,96 +1,103 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { Match } from '../types';
 import { MatchListItem } from './MatchListItem';
-import { SearchIcon, RefreshIcon } from './Icons';
+import { RefreshIcon, SearchIcon } from './Icons';
 
 interface MatchListProps {
   matches: Match[];
-  setMatches: React.Dispatch<React.SetStateAction<Match[]>>;
   attendedMatchIds: string[];
   onAttend: (match: Match) => void;
-  onUnattend: (matchId: string) => void;
   onRefresh: () => void;
 }
 
-export const MatchList: React.FC<MatchListProps> = ({ matches, attendedMatchIds, onAttend, onUnattend, onRefresh }) => {
-    
-    const [searchQuery, setSearchQuery] = useState('');
-    
-    const upcomingMatches = useMemo(() => {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0); // Set to start of today for accurate comparison
+export const MatchList: React.FC<MatchListProps> = ({ matches, attendedMatchIds, onAttend, onRefresh }) => {
+  const [searchQuery, setSearchQuery] = useState('');
 
-        const sevenDaysFromNow = new Date(today);
-        sevenDaysFromNow.setDate(today.getDate() + 7);
+  const { upcomingMatches, filteredMatches } = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
 
-        return matches.filter(match => {
-            const matchDate = new Date(match.startTime);
-            return matchDate >= today && matchDate < sevenDaysFromNow;
-        });
-    }, [matches]);
+    const sevenDaysFromNow = new Date(today);
+    sevenDaysFromNow.setDate(today.getDate() + 7);
 
-    const filteredMatches = useMemo(() => {
-        if (!searchQuery) {
-            return upcomingMatches;
-        }
-        return upcomingMatches.filter(match =>
-            (match.homeTeam?.name?.toLowerCase().includes(searchQuery.toLowerCase())) ||
-            (match.awayTeam?.name?.toLowerCase().includes(searchQuery.toLowerCase()))
-        );
-    }, [upcomingMatches, searchQuery]);
+    const normalizedQuery = searchQuery.trim().toLowerCase();
 
-    return (
-        <div className="space-y-8">
-            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-border pb-4">
-                <div className="flex items-center gap-3">
-                    <h1 className="text-3xl font-bold text-text-strong">Matches in the Next 7 Days</h1>
-                    <button 
-                        onClick={onRefresh}
-                        className="p-2 rounded-full text-text-subtle hover:bg-surface-alt transition-colors"
-                        aria-label="Refresh matches"
-                    >
-                        <RefreshIcon className="w-6 h-6"/>
-                    </button>
-                </div>
-                <div className="relative">
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <SearchIcon className="w-5 h-5 text-text-subtle" />
-                    </div>
-                    <input
-                        type="text"
-                        placeholder="Filter by team name..."
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        className="w-full md:w-64 bg-surface text-text placeholder-text-subtle border border-border rounded-md py-2 pl-10 pr-4 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                    />
-                </div>
-            </div>
+    const upcoming = matches
+      .filter(match => {
+        const matchDate = new Date(match.startTime);
+        return matchDate >= today && matchDate < sevenDaysFromNow;
+      })
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 
-            {upcomingMatches.length === 0 ? (
-                <div className="text-center py-20 bg-surface rounded-md text-text">
-                    <h2 className="text-2xl font-bold text-text-strong">No Matches Scheduled</h2>
-                    <p className="text-text-subtle mt-2">There are no matches scheduled in the next 7 days.</p>
-                </div>
-            ) : filteredMatches.length === 0 ? (
-                <div className="text-center py-20 bg-surface rounded-md text-text">
-                    <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
-                    <p className="text-text-subtle mt-2">No upcoming matches found for "{searchQuery}". Try a different search.</p>
-                </div>
-            ) : (
-                <div className="space-y-4">
-                    {filteredMatches
-                        .sort((a,b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
-                        .map(match => (
-                        <MatchListItem
-                            key={match.id}
-                            match={match}
-                            isAttended={attendedMatchIds.includes(match.id)}
-                            onAttend={onAttend}
-                            onUnattend={onUnattend}
-                         />
-                    ))}
-                </div>
-            )}
+    const filtered = normalizedQuery
+      ? upcoming.filter(match => {
+          const home = match.homeTeam?.name?.toLowerCase() ?? '';
+          const away = match.awayTeam?.name?.toLowerCase() ?? '';
+          return home.includes(normalizedQuery) || away.includes(normalizedQuery);
+        })
+      : upcoming;
+
+    return { upcomingMatches: upcoming, filteredMatches: filtered };
+  }, [matches, searchQuery]);
+
+  const showNoMatchesMessage = upcomingMatches.length === 0;
+  const showNoResultsMessage = !showNoMatchesMessage && filteredMatches.length === 0;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 border-b border-border pb-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold text-text-strong">Matches in the Next 7 Days</h1>
+          <button
+            onClick={onRefresh}
+            className="rounded-full p-2 text-text-subtle transition-colors hover:bg-surface-alt"
+            aria-label="Refresh matches"
+          >
+            <RefreshIcon className="h-6 w-6" />
+          </button>
         </div>
-    );
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <SearchIcon className="h-5 w-5 text-text-subtle" />
+          </div>
+          <input
+            type="text"
+            placeholder="Filter by team name..."
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+            className="w-full rounded-md border border-border bg-surface py-2 pl-10 pr-4 text-text placeholder:text-text-subtle focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary md:w-64"
+          />
+        </div>
+      </div>
+
+      {showNoMatchesMessage && (
+        <div className="rounded-md bg-surface py-20 text-center text-text">
+          <h2 className="text-2xl font-bold text-text-strong">No Matches Scheduled</h2>
+          <p className="mt-2 text-text-subtle">There are no matches scheduled in the next 7 days.</p>
+        </div>
+      )}
+
+      {showNoResultsMessage && (
+        <div className="rounded-md bg-surface py-20 text-center text-text">
+          <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
+          <p className="mt-2 text-text-subtle">
+            No upcoming matches found for "{searchQuery}". Try a different search.
+          </p>
+        </div>
+      )}
+
+      {!showNoMatchesMessage && !showNoResultsMessage && (
+        <div className="space-y-4">
+          {filteredMatches.map(match => (
+            <MatchListItem
+              key={match.id}
+              match={match}
+              isAttended={attendedMatchIds.includes(match.id)}
+              onAttend={onAttend}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };

--- a/components/MatchListItem.tsx
+++ b/components/MatchListItem.tsx
@@ -1,7 +1,13 @@
-
 import React, { useState } from 'react';
 import type { Match } from '../types';
-import { CheckCircleIcon, PlusCircleIcon, ClockIcon, LocationMarkerIcon, CalendarPlusIcon, MiniSpinnerIcon } from './Icons';
+import {
+  CalendarPlusIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  LocationMarkerIcon,
+  MiniSpinnerIcon,
+  PlusCircleIcon,
+} from './Icons';
 import { TeamLogo } from './TeamLogo';
 import { ALL_VENUES } from '../services/mockData';
 import { getDistance } from '../utils/geolocation';
@@ -10,223 +16,233 @@ interface MatchListItemProps {
   match: Match;
   isAttended: boolean;
   onAttend: (match: Match) => void;
-  onUnattend: (matchId: string) => void;
   distance?: number;
 }
 
 const CHECKIN_RADIUS_MILES = 1.0;
+const CHECKIN_RESET_DELAY = 3000;
 
 const isToday = (dateString: string): boolean => {
-    const today = new Date();
-    const someDate = new Date(dateString);
-    return someDate.getDate() === today.getDate() &&
-        someDate.getMonth() === today.getMonth() &&
-        someDate.getFullYear() === today.getFullYear();
+  const today = new Date();
+  const someDate = new Date(dateString);
+  return (
+    someDate.getDate() === today.getDate() &&
+    someDate.getMonth() === today.getMonth() &&
+    someDate.getFullYear() === today.getFullYear()
+  );
 };
 
+const formatICalDate = (date: Date) => date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
 
-export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended, onAttend, onUnattend, distance }) => {
-    const [checkinState, setCheckinState] = useState<{
-        status: 'idle' | 'checking' | 'error_distance' | 'error_location';
-        message: string;
-    }>({ status: 'idle', message: '' });
+export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended, onAttend, distance }) => {
+  const [checkinState, setCheckinState] = useState<{
+    status: 'idle' | 'checking' | 'error_distance' | 'error_location';
+    message: string;
+  }>({ status: 'idle', message: '' });
 
-    const isFT = match.status === 'FULL-TIME';
-    const isScheduled = match.status === 'SCHEDULED';
-    const matchIsToday = isToday(match.startTime);
-    
-    const handleMarkAsAttended = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onAttend(match);
+  const isFullTime = match.status === 'FULL-TIME';
+  const isScheduled = match.status === 'SCHEDULED';
+  const matchIsToday = isToday(match.startTime);
+  const matchTime = new Date(match.startTime).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+  const resetCheckinState = () => {
+    setTimeout(() => setCheckinState({ status: 'idle', message: '' }), CHECKIN_RESET_DELAY);
+  };
+
+  const handleMarkAsAttended = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onAttend(match);
+  };
+
+  const handleAddToCalendar = (event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    const startDate = new Date(match.startTime);
+    const endDate = new Date(startDate.getTime() + 105 * 60 * 1000);
+
+    const icsContent = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'BEGIN:VEVENT',
+      `UID:${match.id}@thescrumbook.com`,
+      `DTSTAMP:${formatICalDate(new Date())}`,
+      `DTSTART:${formatICalDate(startDate)}`,
+      `DTEND:${formatICalDate(endDate)}`,
+      `SUMMARY:${match.homeTeam.name} vs ${match.awayTeam.name}`,
+      `DESCRIPTION:Betfred Super League: ${match.homeTeam.name} vs ${match.awayTeam.name}`,
+      `LOCATION:${match.venue}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    const fileName = `${match.homeTeam.name.replace(/\s/g, '_')}-vs-${match.awayTeam.name.replace(/\s/g, '_')}.ics`;
+    link.setAttribute('download', fileName);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleCheckIn = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setCheckinState({ status: 'checking', message: 'Checking location...' });
+
+    const handleLocationError = (message: string, status: 'error_distance' | 'error_location') => {
+      setCheckinState({ status, message });
+      resetCheckinState();
     };
 
-    const handleAddToCalendar = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    if (!navigator.geolocation) {
+      handleLocationError('Location not supported', 'error_location');
+      return;
+    }
 
-        const formatICalDate = (date: Date) => {
-            return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-        };
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const { latitude, longitude } = position.coords;
+        const stadium = ALL_VENUES.find(venue => venue.name === match.venue);
 
-        const startDate = new Date(match.startTime);
-        const endDate = new Date(startDate.getTime() + 105 * 60 * 1000);
-
-        const icsContent = [
-            'BEGIN:VCALENDAR',
-            'VERSION:2.0',
-            'BEGIN:VEVENT',
-            `UID:${match.id}@thescrumbook.com`,
-            `DTSTAMP:${formatICalDate(new Date())}`,
-            `DTSTART:${formatICalDate(startDate)}`,
-            `DTEND:${formatICalDate(endDate)}`,
-            `SUMMARY:${match.homeTeam.name} vs ${match.awayTeam.name}`,
-            `DESCRIPTION:Betfred Super League: ${match.homeTeam.name} vs ${match.awayTeam.name}`,
-            `LOCATION:${match.venue}`,
-            'END:VEVENT',
-            'END:VCALENDAR'
-        ].join('\r\n');
-
-        const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        
-        const link = document.createElement('a');
-        link.href = url;
-        const fileName = `${match.homeTeam.name.replace(/\s/g, '_')}-vs-${match.awayTeam.name.replace(/\s/g, '_')}.ics`;
-        link.setAttribute('download', fileName);
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
-    };
-    
-    const handleCheckIn = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setCheckinState({ status: 'checking', message: 'Checking Location...' });
-
-        navigator.geolocation.getCurrentPosition(
-            (position) => {
-                const { latitude, longitude } = position.coords;
-                const stadium = ALL_VENUES.find(v => v.name === match.venue);
-
-                if (!stadium) {
-                    setCheckinState({ status: 'error_location', message: 'Stadium location unknown' });
-                    setTimeout(() => setCheckinState({ status: 'idle', message: '' }), 3000);
-                    return;
-                }
-
-                const distance = getDistance(latitude, longitude, stadium.lat, stadium.lon);
-
-                if (distance <= CHECKIN_RADIUS_MILES) {
-                    onAttend(match);
-                } else {
-                    setCheckinState({ status: 'error_distance', message: `Too far away (${distance.toFixed(1)} mi)` });
-                     setTimeout(() => setCheckinState({ status: 'idle', message: '' }), 3000);
-                }
-            },
-            (error) => {
-                console.error("Geolocation error:", error);
-                setCheckinState({ status: 'error_location', message: 'Location unavailable' });
-                setTimeout(() => setCheckinState({ status: 'idle', message: '' }), 3000);
-            },
-            { timeout: 10000, enableHighAccuracy: true }
-        );
-    };
-
-    const time = new Date(match.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-
-    const renderAttendButton = () => {
-        if (isAttended) {
-            return (
-                <button
-                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold bg-secondary text-white cursor-default"
-                    disabled
-                >
-                    <CheckCircleIcon className="w-4 h-4" />
-                    <span>Attended</span>
-                </button>
-            );
+        if (!stadium) {
+          handleLocationError('Stadium location unknown', 'error_location');
+          return;
         }
-    
-        if (matchIsToday && !isFT) {
-            const isChecking = checkinState.status === 'checking';
-            const isError = checkinState.status.startsWith('error');
-            
-            let buttonClass = 'bg-info text-white hover:bg-info/90';
-            if (isError) buttonClass = 'bg-danger text-white';
-            if (isChecking) buttonClass = 'bg-info/80 text-white cursor-wait';
-    
-            return (
-                <button
-                    onClick={handleCheckIn}
-                    disabled={isChecking}
-                    className={`flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-surface-alt focus:ring-primary w-32 ${buttonClass}`}
-                >
-                    {isChecking && <MiniSpinnerIcon className="w-4 h-4" />}
-                    {!isChecking && <LocationMarkerIcon className="w-4 h-4" />}
-                    <span>{checkinState.status !== 'idle' ? checkinState.message : 'Check In'}</span>
-                </button>
-            );
+
+        const userDistance = getDistance(latitude, longitude, stadium.lat, stadium.lon);
+
+        if (userDistance <= CHECKIN_RADIUS_MILES) {
+          onAttend(match);
+          setCheckinState({ status: 'idle', message: '' });
+        } else {
+          handleLocationError(`Too far away (${userDistance.toFixed(1)} mi)`, 'error_distance');
         }
-        
-        return (
-            <button
-                onClick={handleMarkAsAttended}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-surface-alt focus:ring-primary bg-transparent border border-secondary text-secondary hover:bg-secondary/10"
-            >
-                <PlusCircleIcon className="w-4 h-4" />
-                <span className="hidden sm:inline">I was there</span>
-                <span className="sm:hidden">Attend</span>
-            </button>
-        );
-    };
+      },
+      error => {
+        console.error('Geolocation error:', error);
+        handleLocationError('Location unavailable', 'error_location');
+      },
+      { timeout: 10000, enableHighAccuracy: true },
+    );
+  };
+
+  const renderAttendButton = () => {
+    if (isAttended) {
+      return (
+        <button className="flex cursor-default items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-semibold text-white" disabled>
+          <CheckCircleIcon className="h-4 w-4" />
+          <span>Attended</span>
+        </button>
+      );
+    }
+
+    if (matchIsToday && !isFullTime) {
+      const isChecking = checkinState.status === 'checking';
+      const isError = checkinState.status.startsWith('error');
+
+      let buttonClass = 'bg-info text-white hover:bg-info/90';
+      if (isError) buttonClass = 'bg-danger text-white';
+      if (isChecking) buttonClass = 'bg-info/80 text-white cursor-wait';
+
+      return (
+        <button
+          onClick={handleCheckIn}
+          disabled={isChecking}
+          className={`flex w-32 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt ${buttonClass}`}
+        >
+          {isChecking && <MiniSpinnerIcon className="h-4 w-4" />}
+          {!isChecking && <LocationMarkerIcon className="h-4 w-4" />}
+          <span>{checkinState.status !== 'idle' ? checkinState.message : 'Check In'}</span>
+        </button>
+      );
+    }
 
     return (
-    <article className="bg-surface rounded-md shadow-card overflow-hidden transition-shadow duration-300 hover:shadow-lg">
-        <div className="p-4 grid grid-cols-[1fr_auto_1fr] gap-3 items-center">
-            {/* Home Team */}
-            <div className="flex items-center gap-3 min-w-0">
-                <TeamLogo teamId={match.homeTeam?.id} teamName={match.homeTeam?.name || 'Home'} size="medium" />
-                <span className="font-semibold text-sm md:text-base text-text-strong truncate">{match.homeTeam?.name || 'Home Team'}</span>
-            </div>
-
-            {/* Score & Status */}
-            <div className="text-center">
-                <div className="text-4xl font-extrabold text-text-strong [font-variant-numeric:tabular-nums] flex justify-center items-center gap-2 min-h-[40px]">
-                    {isFT ? (
-                        <>
-                            <span>{match.scores.home}</span>
-                            <span>-</span>
-                            <span>{match.scores.away}</span>
-                        </>
-                    ) : (
-                        <span className="text-2xl font-semibold text-text-subtle tracking-wider">VS</span>
-                    )}
-                </div>
-                <div className={`inline-flex items-center gap-2 px-2 py-1 mt-1 rounded-md text-xs font-semibold ${
-                    isFT ? 'bg-accent text-text-strong' : 'bg-surface-alt text-text-subtle'
-                }`}>
-                    {isFT ? 'FT' : time}
-                </div>
-            </div>
-
-            {/* Away Team */}
-            <div className="flex items-center gap-3 justify-end min-w-0">
-                <span className="font-semibold text-sm md:text-base text-text-strong truncate text-right">{match.awayTeam?.name || 'Away Team'}</span>
-                <TeamLogo teamId={match.awayTeam?.id} teamName={match.awayTeam?.name || 'Away'} size="medium" />
-            </div>
-        </div>
-
-        <div className="bg-surface-alt px-4 py-3 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 text-sm border-t border-border">
-            <div className="flex items-center gap-x-4 gap-y-1 text-text-subtle flex-wrap">
-                <div className="flex items-center gap-1.5">
-                    <LocationMarkerIcon className="w-4 h-4" />
-                    <span>{match.venue}</span>
-                </div>
-                 <div className="flex items-center gap-1.5">
-                    <ClockIcon className="w-4 h-4" />
-                    <span>{new Date(match.startTime).toLocaleDateString()}</span>
-                </div>
-                {distance !== undefined && (
-                    <div className="font-semibold text-primary">
-                        <span>{distance.toFixed(1)} mi away</span>
-                    </div>
-                )}
-            </div>
-            
-            <div className="flex items-center gap-2 self-end sm:self-auto">
-                {isScheduled && (
-                    <button
-                        onClick={handleAddToCalendar}
-                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-colors duration-200 bg-transparent border border-info text-info hover:bg-info/10 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-surface-alt focus:ring-primary"
-                        aria-label="Add match to calendar"
-                    >
-                        <CalendarPlusIcon className="w-4 h-4" />
-                        <span className="hidden sm:inline">Add to Calendar</span>
-                        <span className="sm:hidden">Calendar</span>
-                    </button>
-                )}
-                {renderAttendButton()}
-            </div>
-        </div>
-    </article>
+      <button
+        onClick={handleMarkAsAttended}
+        className="flex items-center gap-1.5 rounded-md border border-secondary px-3 py-1.5 text-xs font-semibold text-secondary transition-colors duration-200 hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt"
+      >
+        <PlusCircleIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">I was there</span>
+        <span className="sm:hidden">Attend</span>
+      </button>
     );
+  };
+
+  return (
+    <article className="overflow-hidden rounded-md bg-surface shadow-card transition-shadow duration-300 hover:shadow-lg">
+      <div className="grid items-center gap-3 p-4 [grid-template-columns:1fr_auto_1fr]">
+        <div className="flex min-w-0 items-center gap-3">
+          <TeamLogo teamId={match.homeTeam?.id} teamName={match.homeTeam?.name ?? 'Home'} size="medium" />
+          <span className="truncate text-sm font-semibold text-text-strong md:text-base">{match.homeTeam?.name ?? 'Home Team'}</span>
+        </div>
+
+        <div className="text-center">
+          <div className="flex min-h-[40px] items-center justify-center gap-2 text-4xl font-extrabold text-text-strong [font-variant-numeric:tabular-nums]">
+            {isFullTime ? (
+              <>
+                <span>{match.scores.home}</span>
+                <span>-</span>
+                <span>{match.scores.away}</span>
+              </>
+            ) : (
+              <span className="text-2xl font-semibold tracking-wider text-text-subtle">VS</span>
+            )}
+          </div>
+          <div
+            className={`mt-1 inline-flex items-center gap-2 rounded-md px-2 py-1 text-xs font-semibold ${
+              isFullTime ? 'bg-accent text-text-strong' : 'bg-surface-alt text-text-subtle'
+            }`}
+          >
+            {isFullTime ? 'FT' : matchTime}
+          </div>
+        </div>
+
+        <div className="flex min-w-0 items-center justify-end gap-3">
+          <span className="truncate text-right text-sm font-semibold text-text-strong md:text-base">{match.awayTeam?.name ?? 'Away Team'}</span>
+          <TeamLogo teamId={match.awayTeam?.id} teamName={match.awayTeam?.name ?? 'Away'} size="medium" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-border bg-surface-alt px-4 py-3 text-sm text-text-subtle sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          <div className="flex items-center gap-1.5">
+            <LocationMarkerIcon className="h-4 w-4" />
+            <span>{match.venue}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ClockIcon className="h-4 w-4" />
+            <span>{new Date(match.startTime).toLocaleDateString()}</span>
+          </div>
+          {distance !== undefined && (
+            <div className="font-semibold text-primary">
+              <span>{distance.toFixed(1)} mi away</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 self-end sm:self-auto">
+          {isScheduled && (
+            <button
+              onClick={handleAddToCalendar}
+              className="flex items-center gap-1.5 rounded-md border border-info px-3 py-1.5 text-xs font-semibold text-info transition-colors duration-200 hover:bg-info/10 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt"
+              aria-label="Add match to calendar"
+            >
+              <CalendarPlusIcon className="h-4 w-4" />
+              <span className="hidden sm:inline">Add to Calendar</span>
+              <span className="sm:hidden">Calendar</span>
+            </button>
+          )}
+          {renderAttendButton()}
+        </div>
+      </div>
+    </article>
+  );
 };

--- a/components/MatchdayView.tsx
+++ b/components/MatchdayView.tsx
@@ -6,120 +6,120 @@ interface MatchdayViewProps {
   matches: Match[];
   attendedMatchIds: string[];
   onAttend: (match: Match) => void;
-  onUnattend: (matchId: string) => void;
 }
 
 const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString(undefined, {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-    });
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 };
 
 type ActiveTab = 'fixtures' | 'results';
 
-export const MatchdayView: React.FC<MatchdayViewProps> = ({ matches, attendedMatchIds, onAttend, onUnattend }) => {
-    const [activeTab, setActiveTab] = useState<ActiveTab>('results');
+type TabButtonProps = {
+  tab: ActiveTab;
+  label: string;
+  isActive: boolean;
+  onClick: (tab: ActiveTab) => void;
+};
 
-    const { fixtures, results } = useMemo(() => {
-        const fixturesList = matches
-            .filter(match => match.status === 'SCHEDULED')
-            .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-        
-        const resultsList = matches
-            .filter(match => match.status === 'FULL-TIME')
-            .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
-            
-        return { fixtures: fixturesList, results: resultsList };
-    }, [matches]);
+const TabButton: React.FC<TabButtonProps> = ({ tab, label, isActive, onClick }) => (
+  <button
+    onClick={() => onClick(tab)}
+    className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/50 ${
+      isActive ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-text-subtle hover:bg-surface hover:text-text'
+    }`}
+  >
+    {label}
+  </button>
+);
 
-    const matchesToDisplay = activeTab === 'fixtures' ? fixtures : results;
+export const MatchdayView: React.FC<MatchdayViewProps> = ({ matches, attendedMatchIds, onAttend }) => {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('results');
 
-    const groupedMatches = useMemo(() => {
-        return matchesToDisplay.reduce((acc, match) => {
-            const dateKey = new Date(match.startTime).toDateString();
-            if (!acc[dateKey]) {
-                acc[dateKey] = [];
-            }
-            acc[dateKey].push(match);
-            return acc;
-        }, {} as Record<string, Match[]>);
-    }, [matchesToDisplay]);
+  const { fixtures, results } = useMemo(() => {
+    const fixturesList = matches
+      .filter(match => match.status === 'SCHEDULED')
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 
-    const sortedDateKeys = Object.keys(groupedMatches); // Keys are already in order due to pre-sorting matchesToDisplay
+    const resultsList = matches
+      .filter(match => match.status === 'FULL-TIME')
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
 
-    const TabButton: React.FC<{ tab: ActiveTab; label: string; }> = ({ tab, label }) => {
-        const isActive = activeTab === tab;
-        return (
-             <button
-                onClick={() => setActiveTab(tab)}
-                className={`px-4 py-2 text-sm font-semibold rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/50 ${
-                    isActive
-                        ? 'bg-primary text-white shadow-sm'
-                        : 'bg-transparent text-text-subtle hover:bg-surface hover:text-text'
-                }`}
-            >
-                {label}
-            </button>
-        )
+    return { fixtures: fixturesList, results: resultsList };
+  }, [matches]);
+
+  const matchesToDisplay = activeTab === 'fixtures' ? fixtures : results;
+
+  const groupedMatches = useMemo(() => {
+    return matchesToDisplay.reduce<Record<string, Match[]>>((accumulator, match) => {
+      const dateKey = new Date(match.startTime).toDateString();
+      if (!accumulator[dateKey]) {
+        accumulator[dateKey] = [];
+      }
+      accumulator[dateKey].push(match);
+      return accumulator;
+    }, {});
+  }, [matchesToDisplay]);
+
+  const sortedDateKeys = Object.keys(groupedMatches);
+
+  const renderMatchList = () => {
+    if (sortedDateKeys.length === 0) {
+      return (
+        <div className="rounded-md bg-surface py-20 text-center">
+          <h2 className="text-2xl font-bold text-text-strong">
+            {activeTab === 'fixtures' ? 'No Upcoming Fixtures' : 'No Past Results'}
+          </h2>
+          <p className="mt-2 text-text-subtle">
+            {activeTab === 'fixtures'
+              ? 'Check back later for more scheduled matches.'
+              : 'There are no results to display for this season.'}
+          </p>
+        </div>
+      );
     }
 
-    const renderMatchList = () => {
-        if (sortedDateKeys.length === 0) {
-            return (
-                <div className="text-center py-20 bg-surface rounded-md">
-                    <h2 className="text-2xl font-bold text-text-strong">
-                        {activeTab === 'fixtures' ? 'No Upcoming Fixtures' : 'No Past Results'}
-                    </h2>
-                    <p className="text-text-subtle mt-2">
-                        {activeTab === 'fixtures' 
-                            ? 'Check back later for more scheduled matches.' 
-                            : 'There are no results to display for this season.'}
-                    </p>
-                </div>
-            );
-        }
-
-        return (
-             <div className="space-y-8">
-                {sortedDateKeys.map(dateKey => (
-                    <div key={dateKey}>
-                        <h2 className="text-xl font-bold text-text-strong border-b-2 border-primary pb-2 mb-4">
-                            {formatDate(dateKey)}
-                        </h2>
-                        <div className="space-y-4">
-                            {groupedMatches[dateKey].map(match => (
-                                <MatchListItem
-                                    key={match.id}
-                                    match={match}
-                                    isAttended={attendedMatchIds.includes(match.id)}
-                                    onAttend={onAttend}
-                                    onUnattend={onUnattend}
-                                />
-                            ))}
-                        </div>
-                    </div>
-                ))}
-            </div>
-        );
-    };
-
     return (
-        <div className="space-y-6">
-            <div className="border-b border-border pb-4">
-                <h1 className="text-3xl font-bold text-text-strong">Fixtures & Results</h1>
-                <p className="text-text-subtle mt-1">View upcoming matches or past results for the season.</p>
+      <div className="space-y-8">
+        {sortedDateKeys.map(dateKey => (
+          <div key={dateKey}>
+            <h2 className="mb-4 border-b-2 border-primary pb-2 text-xl font-bold text-text-strong">
+              {formatDate(dateKey)}
+            </h2>
+            <div className="space-y-4">
+              {groupedMatches[dateKey].map(match => (
+                <MatchListItem
+                  key={match.id}
+                  match={match}
+                  isAttended={attendedMatchIds.includes(match.id)}
+                  onAttend={onAttend}
+                />
+              ))}
             </div>
-
-            <div className="flex items-center gap-2 p-1 bg-surface-alt rounded-xl w-fit">
-                <TabButton tab="results" label="Results" />
-                <TabButton tab="fixtures" label="Fixtures" />
-            </div>
-
-            {renderMatchList()}
-        </div>
+          </div>
+        ))}
+      </div>
     );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="border-b border-border pb-4">
+        <h1 className="text-3xl font-bold text-text-strong">Fixtures &amp; Results</h1>
+        <p className="mt-1 text-text-subtle">View upcoming matches or past results for the season.</p>
+      </div>
+
+      <div className="flex w-fit items-center gap-2 rounded-xl bg-surface-alt p-1">
+        <TabButton tab="results" label="Results" isActive={activeTab === 'results'} onClick={setActiveTab} />
+        <TabButton tab="fixtures" label="Fixtures" isActive={activeTab === 'fixtures'} onClick={setActiveTab} />
+      </div>
+
+      {renderMatchList()}
+    </div>
+  );
 };

--- a/components/NearbyMatchesView.tsx
+++ b/components/NearbyMatchesView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { Match } from '../types';
 import { MatchListItem } from './MatchListItem';
 import { LoadingSpinner } from './LoadingSpinner';
@@ -8,97 +8,100 @@ import { getDistance } from '../utils/geolocation';
 import { ALL_VENUES } from '../services/mockData';
 
 interface NearbyMatch extends Match {
-    distance: number;
+  distance: number;
 }
 
 interface NearbyMatchesViewProps {
-    matches: Match[];
-    attendedMatchIds: string[];
-    onAttend: (match: Match) => void;
-    onUnattend: (matchId: string) => void;
+  matches: Match[];
+  attendedMatchIds: string[];
+  onAttend: (match: Match) => void;
 }
 
-export const NearbyMatchesView: React.FC<NearbyMatchesViewProps> = ({ matches, attendedMatchIds, onAttend, onUnattend }) => {
-    const { position, isLoading, error, requestLocation } = useGeolocation();
-    const [sortedMatches, setSortedMatches] = useState<NearbyMatch[]>([]);
+export const NearbyMatchesView: React.FC<NearbyMatchesViewProps> = ({ matches, attendedMatchIds, onAttend }) => {
+  const { position, isLoading, error, requestLocation } = useGeolocation();
 
-    useEffect(() => {
-        requestLocation();
-    }, [requestLocation]);
+  useEffect(() => {
+    requestLocation();
+  }, [requestLocation]);
 
-    const upcomingMatches = useMemo(() => {
-        return matches.filter(match => new Date(match.startTime) > new Date() && match.status === 'SCHEDULED');
-    }, [matches]);
+  const upcomingMatches = useMemo(
+    () => matches.filter(match => new Date(match.startTime) > new Date() && match.status === 'SCHEDULED'),
+    [matches],
+  );
 
-    useEffect(() => {
-        if (position && upcomingMatches.length > 0) {
-            const matchesWithDistance = upcomingMatches.map(match => {
-                const venue = ALL_VENUES.find(v => v.name === match.venue);
-                if (!venue) return null;
-                const distance = getDistance(position.lat, position.lon, venue.lat, venue.lon);
-                return { ...match, distance };
-            }).filter((m): m is NearbyMatch => m !== null);
-            
-            matchesWithDistance.sort((a, b) => a.distance - b.distance);
-            setSortedMatches(matchesWithDistance);
+  const sortedMatches = useMemo<NearbyMatch[]>(() => {
+    if (!position) {
+      return [];
+    }
+
+    return upcomingMatches
+      .map(match => {
+        const venue = ALL_VENUES.find(v => v.name === match.venue);
+        if (!venue) {
+          return null;
         }
-    }, [position, upcomingMatches]);
-    
-    if (isLoading) {
-        return (
-            <div className="flex flex-col items-center justify-center h-64">
-                <LoadingSpinner />
-                <p className="mt-4 text-text-subtle text-center">Getting your location to find nearby matches...</p>
-            </div>
-        );
-    }
 
-    if (error) {
-        return (
-            <div className="bg-surface p-8 rounded-md text-center flex flex-col items-center shadow-card">
-                <AlertTriangleIcon className="w-12 h-12 text-danger mb-4" />
-                <h2 className="text-xl font-bold text-text-strong mb-2">Location Error</h2>
-                <p className="text-text-subtle mb-6 max-w-md">
-                    {error.code === 1 
-                        ? "You've denied location access. Please enable it in your browser settings to use this feature." 
-                        : "Could not determine your location. Please check your connection and try again."}
-                </p>
-                <button
-                    onClick={requestLocation}
-                    className="bg-primary text-white font-semibold py-2 px-6 rounded-md hover:bg-primary/90 transition-colors duration-200"
-                >
-                    Try Again
-                </button>
-            </div>
-        );
-    }
+        const distance = getDistance(position.lat, position.lon, venue.lat, venue.lon);
+        return { ...match, distance };
+      })
+      .filter((match): match is NearbyMatch => match !== null)
+      .sort((a, b) => a.distance - b.distance);
+  }, [position, upcomingMatches]);
 
+  if (isLoading) {
     return (
-        <div className="space-y-6">
-            <div className="border-b border-border pb-4">
-                <h1 className="text-3xl font-bold text-text-strong">Nearby Matches</h1>
-                <p className="text-text-subtle mt-1">Upcoming Super League matches, sorted by distance.</p>
-            </div>
-
-            {sortedMatches.length === 0 ? (
-                 <div className="text-center py-20 bg-surface rounded-md">
-                    <h2 className="text-2xl font-bold text-text-strong">No Nearby Matches</h2>
-                    <p className="text-text-subtle mt-2">There are no upcoming matches near your location.</p>
-                </div>
-            ) : (
-                <div className="space-y-4">
-                    {sortedMatches.map(match => (
-                         <MatchListItem
-                            key={match.id}
-                            match={match}
-                            isAttended={attendedMatchIds.includes(match.id)}
-                            onAttend={onAttend}
-                            onUnattend={onUnattend}
-                            distance={match.distance}
-                         />
-                    ))}
-                </div>
-            )}
-        </div>
+      <div className="flex h-64 flex-col items-center justify-center">
+        <LoadingSpinner />
+        <p className="mt-4 text-center text-text-subtle">Getting your location to find nearby matches...</p>
+      </div>
     );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center rounded-md bg-surface p-8 text-center shadow-card">
+        <AlertTriangleIcon className="mb-4 h-12 w-12 text-danger" />
+        <h2 className="mb-2 text-xl font-bold text-text-strong">Location Error</h2>
+        <p className="mb-6 max-w-md text-text-subtle">
+          {error.code === 1
+            ? "You've denied location access. Please enable it in your browser settings to use this feature."
+            : 'Could not determine your location. Please check your connection and try again.'}
+        </p>
+        <button
+          onClick={requestLocation}
+          className="rounded-md bg-primary px-6 py-2 font-semibold text-white transition-colors duration-200 hover:bg-primary/90"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="border-b border-border pb-4">
+        <h1 className="text-3xl font-bold text-text-strong">Nearby Matches</h1>
+        <p className="mt-1 text-text-subtle">Upcoming Super League matches, sorted by distance.</p>
+      </div>
+
+      {sortedMatches.length === 0 ? (
+        <div className="rounded-md bg-surface py-20 text-center">
+          <h2 className="text-2xl font-bold text-text-strong">No Nearby Matches</h2>
+          <p className="mt-2 text-text-subtle">There are no upcoming matches near your location.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {sortedMatches.map(match => (
+            <MatchListItem
+              key={match.id}
+              match={match}
+              isAttended={attendedMatchIds.includes(match.id)}
+              onAttend={onAttend}
+              distance={match.distance}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "strict": true
-  },
-  "include": ["vite.config.ts"]
-}
-{
-  "compilerOptions": {
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
@@ -19,9 +8,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "vite.config.ts"],
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- streamline the match list filtering logic and remove unused props while improving empty-state messaging
- tidy the match item, nearby matches, and matchday views for consistent formatting and reduced duplication
- consolidate the project tsconfig into a single valid configuration file

## Testing
- npm run build *(fails: existing duplicate identifier and missing module errors in src/types.ts and src/views/*)*

------
https://chatgpt.com/codex/tasks/task_e_68db82e827f4832cbf4c41f7d1d01484