### PR TITLE
Add GitHub Action for Firebase Hosting deployments

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -1,0 +1,40 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
+

--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ The default fixture list in `services/mockData.ts` mirrors the 2026 season so yo
 
 ---
 
+## Continuous Deployment to Firebase Hosting
+
+This repository includes a GitHub Actions workflow (`.github/workflows/firebase-hosting.yml`) that builds the app and deploys it to Firebase Hosting every time you push to the `main` branch.
+
+1. Create a Firebase service account with the **Firebase Hosting Admin** role and download the JSON credentials file.
+2. In your GitHub repository settings, add the following secrets:
+   - `FIREBASE_SERVICE_ACCOUNT` — the full JSON of the service account credentials.
+   - `FIREBASE_PROJECT_ID` — the target Firebase project ID (for example, `the-scrum-book`).
+3. Update `.firebaserc` so the `default` project matches the value of `FIREBASE_PROJECT_ID`.
+4. Push to `main` (or trigger the workflow manually from the **Actions** tab) to build the project and deploy to Firebase Hosting.
+
+The workflow uses `npm ci` and `npm run build` to ensure the production bundle is valid before publishing. Deployment status is reported directly in the pull request or commit checks.
+
+---
+
 ## Suggested Security Rules
 
 ```text


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the app and deploys to Firebase Hosting
- document the required GitHub secrets and workflow usage in the README

## Testing
- npm run build *(fails: Could not resolve "./components/PredictionGamesView" from "App.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68dc34ce2578832c9b3b2cba7764d0a4