### PR TITLE
Intensify favourite team colour theming

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,7 @@ import { DataUploader } from './components/DataUploader';
 import { CommunityView } from './components/CommunityView';
 import { LoginPromptView } from './components/LoginPromptView';
 import { LogoIcon } from './components/Icons';
+import { syncThemeWithFavouriteTeam } from './utils/themeUtils';
 
 const App: React.FC = () => {
   const [view, setView] = useState<View>('PROFILE');
@@ -33,6 +34,7 @@ const App: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const initialLoadStarted = useRef(false);
+  const favouriteTeamId = profile?.user.favoriteTeamId;
 
   const loadAppData = useCallback(async () => {
     setLoading(true);
@@ -54,6 +56,10 @@ const App: React.FC = () => {
         loadAppData();
     }
   }, [loadAppData]);
+
+  useEffect(() => {
+    syncThemeWithFavouriteTeam(favouriteTeamId, theme === 'dark' ? 'dark' : 'light');
+  }, [favouriteTeamId, theme]);
 
   const handleAttend = (match: Match) => {
     if (!currentUser) {

--- a/utils/themeUtils.ts
+++ b/utils/themeUtils.ts
@@ -1,0 +1,345 @@
+import { TEAM_BRANDING } from '../services/mockData';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeVariables {
+  primary: string;
+  secondary: string;
+  accent: string;
+  danger: string;
+  warning: string;
+  info: string;
+  success: string;
+  textStrong: string;
+  text: string;
+  textSubtle: string;
+  border: string;
+  surface: string;
+  surfaceAlt: string;
+  gradient1: string;
+  gradient2: string;
+  gradient3: string;
+}
+
+const DEFAULT_LIGHT_THEME: ThemeVariables = {
+  primary: '#7F1028',
+  secondary: '#FFD447',
+  accent: '#0052CC',
+  danger: '#7F1028',
+  warning: '#FFD447',
+  info: '#0052CC',
+  success: '#00A86B',
+  textStrong: '#121212',
+  text: '#333333',
+  textSubtle: '#666666',
+  border: '#DDDDDD',
+  surface: '#FFFFFF',
+  surfaceAlt: '#F5F5F5',
+  gradient1: 'linear-gradient(140deg, rgba(127, 16, 40, 0.12), rgba(0, 82, 204, 0.1))',
+  gradient2: 'radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.18), transparent 55%)',
+  gradient3: 'radial-gradient(circle at 80% 0%, rgba(127, 16, 40, 0.14), transparent 45%)',
+};
+
+const DEFAULT_DARK_THEME: ThemeVariables = {
+  primary: '#B71E3C',
+  secondary: '#FFDD57',
+  accent: '#0074FF',
+  danger: '#B71E3C',
+  warning: '#FFDD57',
+  info: '#3B82F6',
+  success: '#22C55E',
+  textStrong: '#FFFFFF',
+  text: '#E0E0E0',
+  textSubtle: '#A0A0A0',
+  border: '#404040',
+  surface: '#1A1A1A',
+  surfaceAlt: '#2C2C2C',
+  gradient1: 'linear-gradient(140deg, rgba(183, 30, 60, 0.24), rgba(0, 116, 255, 0.18))',
+  gradient2: 'radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.22), transparent 60%)',
+  gradient3: 'radial-gradient(circle at 90% 10%, rgba(183, 30, 60, 0.2), transparent 55%)',
+};
+
+const VARIABLE_NAME_MAP: Record<keyof ThemeVariables, string> = {
+  primary: '--clr-primary',
+  secondary: '--clr-secondary',
+  accent: '--clr-accent',
+  danger: '--clr-danger',
+  warning: '--clr-warning',
+  info: '--clr-info',
+  success: '--clr-success',
+  textStrong: '--clr-text-strong',
+  text: '--clr-text',
+  textSubtle: '--clr-text-subtle',
+  border: '--clr-border',
+  surface: '--clr-surface',
+  surfaceAlt: '--clr-surface-alt',
+  gradient1: '--gradient-1',
+  gradient2: '--gradient-2',
+  gradient3: '--gradient-3',
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const hexToRgb = (hex: string): [number, number, number] | null => {
+  const normalised = hex.replace('#', '');
+  if (normalised.length === 3) {
+    const r = normalised[0];
+    const g = normalised[1];
+    const b = normalised[2];
+    return [parseInt(r.repeat(2), 16), parseInt(g.repeat(2), 16), parseInt(b.repeat(2), 16)];
+  }
+
+  if (normalised.length !== 6) {
+    return null;
+  }
+
+  const r = parseInt(normalised.slice(0, 2), 16);
+  const g = parseInt(normalised.slice(2, 4), 16);
+  const b = parseInt(normalised.slice(4, 6), 16);
+
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return null;
+  }
+
+  return [r, g, b];
+};
+
+const rgbToHex = (r: number, g: number, b: number): string => {
+  const toHex = (component: number) => clamp(Math.round(component), 0, 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const mixHexColors = (hexA: string, hexB: string, amount: number): string => {
+  const weight = clamp(amount, 0, 1);
+  const rgbA = hexToRgb(hexA);
+  const rgbB = hexToRgb(hexB);
+
+  if (!rgbA || !rgbB) {
+    return rgbA ? rgbToHex(...rgbA) : hexA;
+  }
+
+  const [rA, gA, bA] = rgbA;
+  const [rB, gB, bB] = rgbB;
+
+  const r = rA + (rB - rA) * weight;
+  const g = gA + (gB - gA) * weight;
+  const b = bA + (bB - bA) * weight;
+
+  return rgbToHex(r, g, b);
+};
+
+const hexToRgba = (hex: string, alpha: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return `rgba(0, 0, 0, ${clamp(alpha, 0, 1)})`;
+  }
+  const [r, g, b] = rgb;
+  return `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1)})`;
+};
+
+const hexToHsl = (hex: string): [number, number, number] | null => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return null;
+  }
+
+  const [r, g, b] = rgb.map(component => component / 255) as [number, number, number];
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  const delta = max - min;
+  if (delta === 0) {
+    return [0, 0, l];
+  }
+
+  s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+
+  switch (max) {
+    case r:
+      h = (g - b) / delta + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / delta + 2;
+      break;
+    case b:
+      h = (r - g) / delta + 4;
+      break;
+    default:
+      h = 0;
+  }
+
+  h /= 6;
+
+  return [h, s, l];
+};
+
+const hueToRgb = (p: number, q: number, t: number) => {
+  let temp = t;
+  if (temp < 0) {
+    temp += 1;
+  }
+  if (temp > 1) {
+    temp -= 1;
+  }
+  if (temp < 1 / 6) {
+    return p + (q - p) * 6 * temp;
+  }
+  if (temp < 1 / 2) {
+    return q;
+  }
+  if (temp < 2 / 3) {
+    return p + (q - p) * (2 / 3 - temp) * 6;
+  }
+  return p;
+};
+
+const hslToHex = (h: number, s: number, l: number): string => {
+  const hue = ((h % 1) + 1) % 1;
+  const saturation = clamp(s, 0, 1);
+  const lightness = clamp(l, 0, 1);
+
+  if (saturation === 0) {
+    const gray = Math.round(lightness * 255);
+    return rgbToHex(gray, gray, gray);
+  }
+
+  const q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+
+  const r = Math.round(hueToRgb(p, q, hue + 1 / 3) * 255);
+  const g = Math.round(hueToRgb(p, q, hue) * 255);
+  const b = Math.round(hueToRgb(p, q, hue - 1 / 3) * 255);
+
+  return rgbToHex(r, g, b);
+};
+
+const adjustColorIntensity = (
+  hex: string,
+  { saturationMultiplier = 1, lightnessMultiplier = 1, lightnessBias = 0 }: {
+    saturationMultiplier?: number;
+    lightnessMultiplier?: number;
+    lightnessBias?: number;
+  },
+): string => {
+  const hsl = hexToHsl(hex);
+  if (!hsl) {
+    return hex;
+  }
+
+  const [h, s, l] = hsl;
+  const adjustedS = clamp(s * saturationMultiplier, 0, 1);
+  const adjustedL = clamp(l * lightnessMultiplier + lightnessBias, 0, 1);
+
+  return hslToHex(h, adjustedS, adjustedL);
+};
+
+const createTeamOverrides = (
+  baseColor: string,
+  textColor: string,
+  mode: ThemeMode,
+  defaults: ThemeVariables,
+): Partial<ThemeVariables> => {
+  const emphasisedBase = adjustColorIntensity(baseColor, {
+    saturationMultiplier: 1.35,
+    lightnessMultiplier: mode === 'dark' ? 1.05 : 0.9,
+  });
+
+  const secondary = adjustColorIntensity(
+    mixHexColors(emphasisedBase, '#FFFFFF', mode === 'dark' ? 0.22 : 0.42),
+    {
+      saturationMultiplier: 1.2,
+      lightnessMultiplier: mode === 'dark' ? 1 : 0.96,
+    },
+  );
+
+  const accent = adjustColorIntensity(
+    mixHexColors(emphasisedBase, textColor, mode === 'dark' ? 0.32 : 0.16),
+    {
+      saturationMultiplier: 1.25,
+      lightnessBias: mode === 'dark' ? 0.02 : -0.02,
+    },
+  );
+
+  const warning = adjustColorIntensity(mixHexColors(emphasisedBase, '#FACC15', mode === 'dark' ? 0.44 : 0.24), {
+    saturationMultiplier: 1.1,
+    lightnessBias: 0.02,
+  });
+
+  const info = adjustColorIntensity(mixHexColors(emphasisedBase, '#38BDF8', mode === 'dark' ? 0.48 : 0.28), {
+    saturationMultiplier: 1.2,
+    lightnessMultiplier: 0.95,
+  });
+
+  const success = adjustColorIntensity(mixHexColors(emphasisedBase, '#22C55E', mode === 'dark' ? 0.52 : 0.3), {
+    saturationMultiplier: 1.25,
+    lightnessMultiplier: 0.96,
+  });
+
+  const border = adjustColorIntensity(mixHexColors(defaults.border, emphasisedBase, mode === 'dark' ? 0.46 : 0.3), {
+    saturationMultiplier: 1.15,
+    lightnessMultiplier: mode === 'dark' ? 1 : 0.92,
+  });
+
+  const surface = mixHexColors(defaults.surface, emphasisedBase, mode === 'dark' ? 0.16 : 0.12);
+  const surfaceAlt = mixHexColors(defaults.surfaceAlt, emphasisedBase, mode === 'dark' ? 0.2 : 0.16);
+
+  const gradient1 = `linear-gradient(135deg, ${hexToRgba(emphasisedBase, mode === 'dark' ? 0.42 : 0.28)}, ${hexToRgba(accent, mode === 'dark' ? 0.24 : 0.18)})`;
+  const gradient2 = `radial-gradient(circle at 20% 15%, ${hexToRgba(secondary, mode === 'dark' ? 0.32 : 0.22)}, transparent 52%)`;
+  const gradient3 = `radial-gradient(circle at 80% 0%, ${hexToRgba(emphasisedBase, mode === 'dark' ? 0.28 : 0.18)}, transparent 42%)`;
+
+  return {
+    primary: emphasisedBase,
+    secondary,
+    accent,
+    danger: emphasisedBase,
+    warning,
+    info,
+    success,
+    border,
+    surface,
+    surfaceAlt,
+    gradient1,
+    gradient2,
+    gradient3,
+  };
+};
+
+const getDefaultsForMode = (mode: ThemeMode) => (mode === 'dark' ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME);
+
+export const getThemeVariables = (teamId: string | undefined, mode: ThemeMode): ThemeVariables => {
+  const defaults = getDefaultsForMode(mode);
+
+  if (!teamId) {
+    return defaults;
+  }
+
+  const branding = TEAM_BRANDING[teamId];
+  if (!branding) {
+    return defaults;
+  }
+
+  const overrides = createTeamOverrides(branding.bg, branding.text, mode, defaults);
+  return { ...defaults, ...overrides };
+};
+
+const applyVariablesToRoot = (variables: ThemeVariables, mode: ThemeMode) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  (Object.keys(VARIABLE_NAME_MAP) as Array<keyof ThemeVariables>).forEach(key => {
+    const cssVar = VARIABLE_NAME_MAP[key];
+    root.style.setProperty(cssVar, variables[key]);
+  });
+
+  root.style.setProperty('color-scheme', mode);
+};
+
+export const syncThemeWithFavouriteTeam = (teamId: string | undefined, mode: ThemeMode) => {
+  const variables = getThemeVariables(teamId, mode);
+  applyVariablesToRoot(variables, mode);
+};


### PR DESCRIPTION
## Summary
- add HSL conversion helpers so theme overrides can amplify team hues without losing accuracy
- deepen and saturate derived palette tokens to deliver bolder primary, accent, and gradient colours per club

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3f74f6fc832cbacef8083699bc4d