### PR TITLE
Restyle profile dashboard with sports-inspired tiles

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -1,17 +1,103 @@
-/* --- Glassmorphism Theme & Base Tile --- */
+/* --- Dynamic Grid Layout Styling --- */
+.layout {
+    position: relative;
+    isolation: isolate;
+}
+.layout::before {
+    content: '';
+    position: absolute;
+    inset: -32px -24px 0;
+    background-image:
+        radial-gradient(circle at 10% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
+        radial-gradient(circle at 85% 15%, rgba(34, 197, 94, 0.2), transparent 60%),
+        repeating-linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0.08) 0,
+            rgba(255, 255, 255, 0.08) 1px,
+            transparent 1px,
+            transparent 48px
+        ),
+        repeating-linear-gradient(
+            0deg,
+            rgba(255, 255, 255, 0.08) 0,
+            rgba(255, 255, 255, 0.08) 1px,
+            transparent 1px,
+            transparent 48px
+        );
+    opacity: 0.18;
+    pointer-events: none;
+    z-index: -1;
+    mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.85), transparent 72%);
+}
+
+:global(.react-grid-layout) {
+    transition: height 0.45s ease;
+}
+:global(.react-grid-item) {
+    transition:
+        transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+        width 0.4s ease,
+        height 0.4s ease;
+}
+:global(.react-grid-item.is-dragging) {
+    z-index: 10;
+    box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.75);
+    transform: scale(1.03) !important;
+}
+:global(.react-grid-item.react-grid-placeholder) {
+    background: rgba(56, 189, 248, 0.2);
+    border: 2px dashed rgba(56, 189, 248, 0.6);
+    border-radius: 20px;
+}
+:global(.react-resizable-handle) {
+    width: 18px;
+    height: 18px;
+    bottom: 12px;
+    right: 12px;
+    border-radius: 6px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.75), rgba(34, 197, 94, 0.75));
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.45);
+}
+:global(.react-resizable-handle::after) {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.65);
+    opacity: 0.75;
+}
+
+/* --- Premium Tile Styling --- */
 .tile {
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 16px;
-    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: var(--clr-text-strong);
-    padding: 1.5rem;
+    position: relative;
+    background: linear-gradient(150deg, rgba(14, 32, 59, 0.92), rgba(10, 74, 104, 0.82));
+    border-radius: 18px;
+    box-shadow: 0 20px 45px -28px rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    color: #f8fafc;
+    padding: 1.75rem;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     height: 100%;
+    transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.35s ease, border-color 0.35s ease;
+}
+.tile::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.4), transparent 60%);
+    opacity: 0.6;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+.tile:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 32px 60px -32px rgba(15, 23, 42, 0.9);
+    border-color: rgba(56, 189, 248, 0.45);
+}
+.tile:hover::before {
+    opacity: 0.85;
 }
 
 /* Edit Mode Toggle */
@@ -20,17 +106,23 @@
     text-align: right;
 }
 .edit_mode_toggle button {
-    background: var(--clr-primary);
-    color: white;
+    background: linear-gradient(135deg, rgba(34, 197, 94, 0.92), rgba(56, 189, 248, 0.92));
+    color: #f8fafc;
     border: none;
-    padding: 0.75rem 1.5rem;
+    padding: 0.75rem 1.75rem;
     border-radius: 9999px;
     font-weight: 600;
+    letter-spacing: 0.01em;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 16px 30px -20px rgba(15, 118, 110, 0.8);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.edit_mode_toggle button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 38px -22px rgba(2, 132, 199, 0.85);
 }
 .edit_mode_toggle button svg {
     width: 1.25em;
@@ -47,39 +139,46 @@
     position: relative;
     flex-shrink: 0;
 }
-.avatar_img, .avatar_placeholder {
+.avatar_img,
+.avatar_placeholder {
     width: 80px;
     height: 80px;
     border-radius: 50%;
     object-fit: cover;
-    border: 3px solid rgba(255, 255, 255, 0.8);
-    background-color: var(--clr-surface-alt);
+    border: 3px solid rgba(255, 255, 255, 0.85);
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.65));
 }
 .avatar_placeholder {
-    color: var(--clr-text-subtle);
+    color: rgba(241, 245, 249, 0.82);
     padding: 0.5rem;
 }
 .edit_avatar_button {
     position: absolute;
     bottom: 0;
     right: 0;
-    background: var(--clr-surface);
-    color: var(--clr-text-strong);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(34, 197, 94, 0.95));
+    color: #0f172a;
     border: none;
     border-radius: 50%;
-    width: 28px;
-    height: 28px;
+    width: 30px;
+    height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 8px 18px -8px rgba(14, 165, 233, 0.9);
+    transition: transform 0.25s ease;
+}
+.edit_avatar_button:hover {
+    transform: scale(1.05);
 }
 .edit_avatar_button svg {
     width: 14px;
     height: 14px;
 }
-.profile_info { flex-grow: 1; }
+.profile_info {
+    flex-grow: 1;
+}
 .profile_name {
     font-size: 1.75rem;
     font-weight: 700;
@@ -89,24 +188,34 @@
     align-items: center;
     gap: 0.5rem;
 }
+.profile_name,
+.profile_status,
+.tile_title,
+.team_name,
+.match_score,
+.nav_tile h4 {
+    text-shadow: 0 2px 4px rgba(15, 23, 42, 0.45);
+}
 .edit_name_icon {
     width: 16px;
     height: 16px;
     opacity: 0.6;
     transition: opacity 0.2s;
 }
-.profile_name:hover .edit_name_icon { opacity: 1; }
+.profile_name:hover .edit_name_icon {
+    opacity: 1;
+}
 .name_edit_form input {
-    background: rgba(0,0,0,0.2);
-    border: 1px solid var(--clr-border);
-    color: var(--clr-text-strong);
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    color: #f8fafc;
     padding: 0.5rem;
     border-radius: 8px;
     font-size: 1.25rem;
 }
 .profile_status {
     margin: 0.25rem 0 0 0;
-    color: var(--clr-text);
+    color: rgba(226, 232, 240, 0.75);
 }
 
 /* --- Content Tiles (Team, Match) --- */
@@ -114,11 +223,14 @@
     font-size: 0.875rem;
     font-weight: 600;
     text-transform: uppercase;
-    opacity: 0.8;
+    letter-spacing: 0.08em;
+    opacity: 0.75;
     margin-bottom: 0.75rem;
     flex-shrink: 0;
 }
-.tile_description, .team_info, .match_recap {
+.tile_description,
+.team_info,
+.match_recap {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -134,21 +246,25 @@
 .match_score {
     font-size: 2rem;
     font-weight: 700;
-    color: var(--clr-primary);
+    color: rgba(56, 189, 248, 0.9);
 }
 .tile_button {
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(15, 23, 42, 0.55);
     border: none;
-    color: inherit;
+    color: rgba(241, 245, 249, 0.9);
     padding: 0.75rem;
-    border-radius: 8px;
+    border-radius: 10px;
     cursor: pointer;
     font-weight: 600;
-    transition: background-color 0.2s;
+    letter-spacing: 0.03em;
+    transition: transform 0.25s ease, background 0.25s ease;
     margin-top: auto;
     flex-shrink: 0;
 }
-.tile_button:hover { background: rgba(0, 0, 0, 0.2); }
+.tile_button:hover {
+    background: rgba(59, 130, 246, 0.2);
+    transform: translateY(-1px);
+}
 
 /* --- Navigation Tiles --- */
 .nav_tile {
@@ -159,15 +275,30 @@
     gap: 0.75rem;
 }
 .nav_tile:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: linear-gradient(160deg, rgba(56, 189, 248, 0.25), rgba(34, 197, 94, 0.25));
 }
 .nav_tile .icon {
     width: 32px;
     height: 32px;
-    color: var(--clr-primary);
+    color: rgba(56, 189, 248, 0.95);
+    filter: drop-shadow(0 6px 12px rgba(14, 165, 233, 0.45));
 }
 .nav_tile h4 {
     margin: 0;
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: 700;
+    color: rgba(248, 250, 252, 0.9);
+}
+
+/* --- Responsive Tweaks --- */
+@media (max-width: 768px) {
+    .profile_tile {
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
+    }
+
+    .profile_info {
+        width: 100%;
+    }
 }

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -119,10 +119,13 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
       </div>
 
       <ResponsiveGridLayout
+        className={styles.layout}
         layouts={layouts}
         breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
         cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
         rowHeight={100}
+        margin={[24, 24]}
+        containerPadding={[0, 24]}
         onLayoutChange={onLayoutChange}
         isDraggable={isEditable}
         isResizable={isEditable}


### PR DESCRIPTION
## Summary
- refresh the profile dashboard with a sports-inspired gradient tile treatment and interactive tray styling
- add grid-level styling so draggable tiles animate and snap with an app-tray style bounce
- increase layout spacing and controls for a sleeker customization experience

## Testing
- npm run build *(fails: missing `react-grid-layout` package in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9c3b6ea0832c8d846dc8865abcf1