### PR TITLE
Polish profile dashboard tiles and stabilize layout persistence

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -1,17 +1,107 @@
-/* --- Glassmorphism Theme & Base Tile --- */
+/* --- Dynamic Grid Layout Styling --- */
+.layout {
+    position: relative;
+    isolation: isolate;
+}
+.layout::before {
+    content: '';
+    position: absolute;
+    inset: -32px -24px 0;
+    background:
+        radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.18), transparent 55%),
+        radial-gradient(circle at 88% 12%, rgba(34, 197, 94, 0.16), transparent 60%),
+        linear-gradient(115deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.65));
+    opacity: 0.22;
+    pointer-events: none;
+    z-index: -1;
+    mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.9), transparent 70%);
+}
+
+:global(.react-grid-layout) {
+    transition: height 0.45s ease;
+}
+:global(.react-grid-item) {
+    transition:
+        transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
+        width 0.4s ease,
+        height 0.4s ease,
+        box-shadow 0.4s ease;
+}
+:global(.react-grid-item.is-dragging) {
+    z-index: 10;
+    box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.75);
+    transform: scale(1.03) !important;
+}
+:global(.react-grid-item.react-grid-placeholder) {
+    background: rgba(56, 189, 248, 0.2);
+    border: 2px dashed rgba(56, 189, 248, 0.6);
+    border-radius: 20px;
+}
+:global(.react-resizable-handle) {
+    width: 18px;
+    height: 18px;
+    bottom: 12px;
+    right: 12px;
+    border-radius: 6px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.75), rgba(34, 197, 94, 0.75));
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.45);
+}
+:global(.react-resizable-handle::after) {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.65);
+    opacity: 0.75;
+}
+
+/* --- Premium Tile Styling --- */
 .tile {
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 16px;
-    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(5px);
-    -webkit-backdrop-filter: blur(5px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: var(--clr-text-strong);
-    padding: 1.5rem;
+    position: relative;
+    background:
+        linear-gradient(152deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92) 55%, rgba(12, 74, 110, 0.9)),
+        radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.22), transparent 55%),
+        radial-gradient(circle at 88% 18%, rgba(34, 197, 94, 0.18), transparent 60%);
+    border-radius: 18px;
+    box-shadow: 0 18px 40px -28px rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    color: #f8fafc;
+    padding: 1.75rem;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     height: 100%;
+    backdrop-filter: saturate(140%) blur(4px);
+    transition:
+        transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+        box-shadow 0.35s ease,
+        border-color 0.35s ease;
+}
+.tile::before,
+.tile::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+.tile::before {
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.15), transparent 62%);
+    opacity: 0.55;
+}
+.tile::after {
+    background: linear-gradient(185deg, rgba(2, 6, 23, 0.25) 0%, rgba(2, 6, 23, 0.45) 88%);
+    mix-blend-mode: multiply;
+    opacity: 0.3;
+}
+.tile:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 55px -28px rgba(15, 23, 42, 0.85);
+    border-color: rgba(56, 189, 248, 0.35);
+}
+.tile:hover::before,
+.tile:hover::after {
+    opacity: 0.75;
 }
 
 /* Edit Mode Toggle */
@@ -20,17 +110,23 @@
     text-align: right;
 }
 .edit_mode_toggle button {
-    background: var(--clr-primary);
-    color: white;
+    background: linear-gradient(135deg, rgba(34, 197, 94, 0.92), rgba(56, 189, 248, 0.92));
+    color: #f8fafc;
     border: none;
-    padding: 0.75rem 1.5rem;
+    padding: 0.75rem 1.75rem;
     border-radius: 9999px;
     font-weight: 600;
+    letter-spacing: 0.01em;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 16px 30px -20px rgba(15, 118, 110, 0.8);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.edit_mode_toggle button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 38px -22px rgba(2, 132, 199, 0.85);
 }
 .edit_mode_toggle button svg {
     width: 1.25em;
@@ -47,39 +143,46 @@
     position: relative;
     flex-shrink: 0;
 }
-.avatar_img, .avatar_placeholder {
+.avatar_img,
+.avatar_placeholder {
     width: 80px;
     height: 80px;
     border-radius: 50%;
     object-fit: cover;
-    border: 3px solid rgba(255, 255, 255, 0.8);
-    background-color: var(--clr-surface-alt);
+    border: 3px solid rgba(255, 255, 255, 0.85);
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.65));
 }
 .avatar_placeholder {
-    color: var(--clr-text-subtle);
+    color: rgba(241, 245, 249, 0.82);
     padding: 0.5rem;
 }
 .edit_avatar_button {
     position: absolute;
     bottom: 0;
     right: 0;
-    background: var(--clr-surface);
-    color: var(--clr-text-strong);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(34, 197, 94, 0.95));
+    color: #0f172a;
     border: none;
     border-radius: 50%;
-    width: 28px;
-    height: 28px;
+    width: 30px;
+    height: 30px;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 8px 18px -8px rgba(14, 165, 233, 0.9);
+    transition: transform 0.25s ease;
+}
+.edit_avatar_button:hover {
+    transform: scale(1.05);
 }
 .edit_avatar_button svg {
     width: 14px;
     height: 14px;
 }
-.profile_info { flex-grow: 1; }
+.profile_info {
+    flex-grow: 1;
+}
 .profile_name {
     font-size: 1.75rem;
     font-weight: 700;
@@ -89,24 +192,48 @@
     align-items: center;
     gap: 0.5rem;
 }
+.profile_name,
+.profile_status,
+.tile_title,
+.team_name,
+.match_score,
+.nav_tile h4 {
+    text-shadow: 0 2px 4px rgba(15, 23, 42, 0.45);
+}
 .edit_name_icon {
     width: 16px;
     height: 16px;
     opacity: 0.6;
     transition: opacity 0.2s;
 }
-.profile_name:hover .edit_name_icon { opacity: 1; }
+.profile_name:hover .edit_name_icon {
+    opacity: 1;
+}
 .name_edit_form input {
-    background: rgba(0,0,0,0.2);
-    border: 1px solid var(--clr-border);
-    color: var(--clr-text-strong);
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    color: #f8fafc;
     padding: 0.5rem;
     border-radius: 8px;
     font-size: 1.25rem;
 }
+.name_edit_form button {
+    margin-left: 0.75rem;
+    padding: 0.45rem 1rem;
+    border-radius: 9999px;
+    border: none;
+    font-weight: 600;
+    cursor: pointer;
+    background: rgba(59, 130, 246, 0.25);
+    color: #e2e8f0;
+    transition: background 0.2s ease;
+}
+.name_edit_form button:hover {
+    background: rgba(56, 189, 248, 0.3);
+}
 .profile_status {
     margin: 0.25rem 0 0 0;
-    color: var(--clr-text);
+    color: rgba(226, 232, 240, 0.75);
 }
 
 /* --- Content Tiles (Team, Match) --- */
@@ -114,11 +241,14 @@
     font-size: 0.875rem;
     font-weight: 600;
     text-transform: uppercase;
-    opacity: 0.8;
+    letter-spacing: 0.08em;
+    opacity: 0.75;
     margin-bottom: 0.75rem;
     flex-shrink: 0;
 }
-.tile_description, .team_info, .match_recap {
+.tile_description,
+.team_info,
+.match_recap {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -134,21 +264,25 @@
 .match_score {
     font-size: 2rem;
     font-weight: 700;
-    color: var(--clr-primary);
+    color: rgba(56, 189, 248, 0.9);
 }
 .tile_button {
-    background: rgba(0, 0, 0, 0.1);
+    background: rgba(15, 23, 42, 0.55);
     border: none;
-    color: inherit;
+    color: rgba(241, 245, 249, 0.9);
     padding: 0.75rem;
-    border-radius: 8px;
+    border-radius: 10px;
     cursor: pointer;
     font-weight: 600;
-    transition: background-color 0.2s;
+    letter-spacing: 0.03em;
+    transition: transform 0.25s ease, background 0.25s ease;
     margin-top: auto;
     flex-shrink: 0;
 }
-.tile_button:hover { background: rgba(0, 0, 0, 0.2); }
+.tile_button:hover {
+    background: rgba(59, 130, 246, 0.2);
+    transform: translateY(-1px);
+}
 
 /* --- Navigation Tiles --- */
 .nav_tile {
@@ -158,16 +292,31 @@
     align-items: center;
     gap: 0.75rem;
 }
-.nav_tile:hover {
-    background: rgba(255, 255, 255, 0.3);
-}
-.nav_tile .icon {
+.icon {
     width: 32px;
     height: 32px;
-    color: var(--clr-primary);
+    color: rgba(56, 189, 248, 0.95);
+    filter: drop-shadow(0 6px 12px rgba(14, 165, 233, 0.45));
+}
+.nav_tile:hover {
+    background: linear-gradient(160deg, rgba(56, 189, 248, 0.25), rgba(34, 197, 94, 0.25));
 }
 .nav_tile h4 {
     margin: 0;
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: 700;
+    color: rgba(248, 250, 252, 0.9);
+}
+
+/* --- Responsive Tweaks --- */
+@media (max-width: 768px) {
+    .profile_tile {
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
+    }
+
+    .profile_info {
+        width: 100%;
+    }
 }

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -19,6 +19,7 @@ import styles from './ProfileView.module.css';
 
 // --- React Grid Layout Imports ---
 import { Responsive, WidthProvider } from 'react-grid-layout';
+import type { Layouts } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 
@@ -40,7 +41,7 @@ interface ProfileViewProps {
 }
 
 // Define the initial layout for the tiles
-const initialLayouts = {
+const initialLayouts: Layouts = {
   lg: [
     { i: 'profile', x: 0, y: 0, w: 12, h: 2, static: true },
     { i: 'team', x: 0, y: 2, w: 4, h: 2 },
@@ -52,6 +53,10 @@ const initialLayouts = {
     { i: 'admin', x: 8, y: 4, w: 4, h: 1 },
     { i: 'logout', x: 8, y: 5, w: 4, h: 1 },
   ],
+  md: [],
+  sm: [],
+  xs: [],
+  xxs: [],
 };
 
 const LAYOUT_STORAGE_KEY = 'profile-tile-layout';
@@ -70,20 +75,29 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
   const [pendingName, setPendingName] = useState(user.name ?? '');
   const [isEditable, setIsEditable] = useState(false);
 
-  const [layouts, setLayouts] = useState(() => {
-    try {
-      const storedLayouts = localStorage.getItem(LAYOUT_STORAGE_KEY);
-      return storedLayouts ? JSON.parse(storedLayouts) : initialLayouts;
-    } catch (error) {
-      return initialLayouts;
+  const [layouts, setLayouts] = useState<Layouts>(initialLayouts);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
     }
-  });
+
+    try {
+      const storedLayouts = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (storedLayouts) {
+        const parsedLayouts = JSON.parse(storedLayouts) as Layouts;
+        setLayouts((prevLayouts: Layouts) => ({ ...prevLayouts, ...parsedLayouts }));
+      }
+    } catch (error) {
+      console.warn('Unable to load saved profile layout', error);
+    }
+  }, []);
 
   useEffect(() => {
     setPendingName(user.name ?? '');
   }, [user.name]);
 
-  const favouriteTeam = useMemo(() => getTeamById(user.favoriteTeamId), [user.favoriteTeamId]);
+  const favoriteTeam = useMemo(() => getTeamById(user.favoriteTeamId), [user.favoriteTeamId]);
   const recentMatch = useMemo(() => {
     if (attendedMatches.length === 0) return null;
     return [...attendedMatches].sort((a, b) => new Date(b.attendedOn).getTime() - new Date(a.attendedOn).getTime())[0];
@@ -104,8 +118,15 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
     setIsAvatarModalOpen(false);
   };
 
-  const onLayoutChange = (layout: any, allLayouts: any) => {
-    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(allLayouts));
+  const onLayoutChange = (_currentLayout: unknown, allLayouts: Layouts) => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(allLayouts));
+      } catch (error) {
+        console.warn('Unable to persist profile layout', error);
+      }
+    }
+
     setLayouts(allLayouts);
   };
 
@@ -119,10 +140,13 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
       </div>
 
       <ResponsiveGridLayout
+        className={styles.layout}
         layouts={layouts}
         breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
         cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
         rowHeight={100}
+        margin={[24, 24]}
+        containerPadding={[0, 24]}
         onLayoutChange={onLayoutChange}
         isDraggable={isEditable}
         isResizable={isEditable}
@@ -158,16 +182,16 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
 
         <div key="team" className={styles.tile}>
           <h3 className={`${styles.tile_title} no-drag`}>My Team</h3>
-          {favouriteTeam ? (
+          {favoriteTeam ? (
             <div className={`${styles.team_info} no-drag`}>
-              <TeamLogo teamId={favouriteTeam.id} teamName={favouriteTeam.name} />
-              <span className={styles.team_name}>{favouriteTeam.name}</span>
+              <TeamLogo teamId={favoriteTeam.id} teamName={favoriteTeam.name} />
+              <span className={styles.team_name}>{favoriteTeam.name}</span>
             </div>
           ) : (
             <p className={`${styles.tile_description} no-drag`}>No favorite team selected.</p>
           )}
           <button onClick={() => setIsTeamModalOpen(true)} className={`${styles.tile_button} no-drag`}>
-            {favouriteTeam ? 'Change' : 'Select'} Team
+            {favoriteTeam ? 'Change' : 'Select'} Team
           </button>
         </div>
         


### PR DESCRIPTION
## Summary
- refine the profile dashboard tiles with a muted sports-inspired palette, subtle glass depth, and consistent icon styling
- align inline name editing controls with the dashboard treatment for clearer interactions
- harden layout persistence by typing `react-grid-layout` usage and guarding localStorage access

## Testing
- npm run build *(fails: Cannot find module 'react-grid-layout' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9c3b6ea0832c8d846dc8865abcf1