### PR TITLE
Enhance profile page aesthetics

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -201,7 +201,6 @@
     gap: 0.5rem;
 }
 .profile_name,
-.profile_status,
 .tile_title,
 .team_name,
 .match_score,
@@ -239,9 +238,66 @@
 .name_edit_form button:hover {
     background: rgba(56, 189, 248, 0.3);
 }
-.profile_status {
-    margin: 0.25rem 0 0 0;
-    color: rgba(226, 232, 240, 0.75);
+.profile_tagline {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.35rem;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: 9999px;
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.18), rgba(34, 197, 94, 0.22));
+    color: rgba(226, 232, 240, 0.9);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.profile_stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
+.stat_chip {
+    position: relative;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.65rem 0.95rem;
+    background: linear-gradient(150deg, rgba(15, 23, 42, 0.7), rgba(30, 41, 59, 0.85));
+    border-radius: 12px;
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.16), 0 12px 20px -18px rgba(2, 132, 199, 0.65);
+    overflow: hidden;
+}
+
+.stat_chip::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), transparent 70%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.stat_chip:hover::after {
+    opacity: 1;
+}
+
+.stat_value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: rgba(56, 189, 248, 0.95);
+    z-index: 1;
+}
+
+.stat_label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(226, 232, 240, 0.72);
+    z-index: 1;
 }
 
 /* --- Content Tiles (Team, Match) --- */
@@ -299,6 +355,7 @@
     justify-content: center;
     align-items: center;
     gap: 0.75rem;
+    position: relative;
 }
 .icon {
 
@@ -308,9 +365,23 @@
     filter: drop-shadow(0 6px 12px rgba(14, 165, 233, 0.45));
 
 }
-.nav_tile:hover {
-    background: linear-gradient(160deg, rgba(56, 189, 248, 0.25), rgba(34, 197, 94, 0.25));
+.nav_tile::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(160deg, rgba(56, 189, 248, 0.18), rgba(34, 197, 94, 0.18));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
 
+.nav_tile:hover::after {
+    opacity: 1;
+}
+
+.nav_tile > * {
+    position: relative;
+    z-index: 1;
 }
 .nav_tile h4 {
     margin: 0;
@@ -329,5 +400,15 @@
 
     .profile_info {
         width: 100%;
+    }
+
+    .profile_stats {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .stat_chip {
+        flex: 1 1 calc(50% - 0.75rem);
+        justify-content: space-between;
     }
 }

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -103,6 +103,23 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
     return [...attendedMatches].sort((a, b) => new Date(b.attendedOn).getTime() - new Date(a.attendedOn).getTime())[0];
   }, [attendedMatches]);
 
+  const profileTagline = useMemo(() => {
+    const matchCount = attendedMatches.length;
+    if (matchCount >= 20) {
+      return 'Stadium Trailblazer';
+    }
+    if (matchCount >= 10) {
+      return 'Matchday Mainstay';
+    }
+    if (matchCount >= 3) {
+      return 'Clubhouse Regular';
+    }
+    if (matchCount > 0) {
+      return 'Fresh on the Pitch';
+    }
+    return 'Ready for Kick-off';
+  }, [attendedMatches.length]);
+
   const handleSaveName = (event: React.FormEvent) => {
     event.preventDefault();
     const trimmed = pendingName.trim();
@@ -174,9 +191,17 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                 {user.name} <PencilIcon className={styles.edit_name_icon} />
               </h1>
             )}
-            <p className={styles.profile_status}>
-              {attendedMatches.length} matches attended | {earnedBadgeIds.length} badges earned
-            </p>
+            <span className={styles.profile_tagline}>{profileTagline}</span>
+            <div className={styles.profile_stats}>
+              <div className={styles.stat_chip}>
+                <span className={styles.stat_value}>{attendedMatches.length}</span>
+                <span className={styles.stat_label}>Matches</span>
+              </div>
+              <div className={styles.stat_chip}>
+                <span className={styles.stat_value}>{earnedBadgeIds.length}</span>
+                <span className={styles.stat_label}>Badges</span>
+              </div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- introduce a dynamic profile tagline and stat chips to highlight match and badge counts
- refresh navigation tile hover treatment to add a subtle layered glow
- adjust responsive styling so the new stat chips scale gracefully on smaller screens

## Testing
- npm run build *(fails: react-grid-layout dependency missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68de02fafcd0832ca6a119b03c81f8bc