### PR TITLE
Simplify profile view layout without react-grid-layout

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -1,9 +1,12 @@
-/* --- Dynamic Grid Layout Styling --- */
-.layout {
+/* --- Grid Layout --- */
+.profile_grid {
     position: relative;
-    isolation: isolate;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
-.layout::before {
+
+.profile_grid::before {
     content: '';
     position: absolute;
     inset: -32px -24px 0;
@@ -15,47 +18,16 @@
     pointer-events: none;
     z-index: -1;
     mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.9), transparent 70%);
-
 }
 
-:global(.react-grid-layout) {
-    transition: height 0.45s ease;
+.profile_tile {
+    grid-column: 1 / -1;
 }
-:global(.react-grid-item) {
-    transition:
-        transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-        width 0.4s ease,
 
-        height 0.4s ease,
-        box-shadow 0.4s ease;
-
-}
-:global(.react-grid-item.is-dragging) {
-    z-index: 10;
-    box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.75);
-    transform: scale(1.03) !important;
-}
-:global(.react-grid-item.react-grid-placeholder) {
-    background: rgba(56, 189, 248, 0.2);
-    border: 2px dashed rgba(56, 189, 248, 0.6);
-    border-radius: 20px;
-}
-:global(.react-resizable-handle) {
-    width: 18px;
-    height: 18px;
-    bottom: 12px;
-    right: 12px;
-    border-radius: 6px;
-    background: linear-gradient(135deg, rgba(56, 189, 248, 0.75), rgba(34, 197, 94, 0.75));
-    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.45);
-}
-:global(.react-resizable-handle::after) {
-    content: '';
-    position: absolute;
-    inset: 4px;
-    border-radius: 4px;
-    background: rgba(255, 255, 255, 0.65);
-    opacity: 0.75;
+@media (min-width: 1024px) {
+    .profile_grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 /* --- Premium Tile Styling --- */
@@ -110,35 +82,6 @@
 .tile:hover::after {
     opacity: 0.75;
 
-}
-
-/* Edit Mode Toggle */
-.edit_mode_toggle {
-    margin-bottom: 1.5rem;
-    text-align: right;
-}
-.edit_mode_toggle button {
-    background: linear-gradient(135deg, rgba(34, 197, 94, 0.92), rgba(56, 189, 248, 0.92));
-    color: #f8fafc;
-    border: none;
-    padding: 0.75rem 1.75rem;
-    border-radius: 9999px;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    box-shadow: 0 16px 30px -20px rgba(15, 118, 110, 0.8);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.edit_mode_toggle button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 24px 38px -22px rgba(2, 132, 199, 0.85);
-}
-.edit_mode_toggle button svg {
-    width: 1.25em;
-    height: 1.25em;
 }
 
 /* --- Profile Tile Specifics --- */
@@ -201,7 +144,6 @@
     gap: 0.5rem;
 }
 .profile_name,
-.profile_status,
 .tile_title,
 .team_name,
 .match_score,
@@ -239,9 +181,66 @@
 .name_edit_form button:hover {
     background: rgba(56, 189, 248, 0.3);
 }
-.profile_status {
-    margin: 0.25rem 0 0 0;
-    color: rgba(226, 232, 240, 0.75);
+.profile_tagline {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.35rem;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: 9999px;
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.18), rgba(34, 197, 94, 0.22));
+    color: rgba(226, 232, 240, 0.9);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.profile_stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+
+.stat_chip {
+    position: relative;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.65rem 0.95rem;
+    background: linear-gradient(150deg, rgba(15, 23, 42, 0.7), rgba(30, 41, 59, 0.85));
+    border-radius: 12px;
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.16), 0 12px 20px -18px rgba(2, 132, 199, 0.65);
+    overflow: hidden;
+}
+
+.stat_chip::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), transparent 70%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.stat_chip:hover::after {
+    opacity: 1;
+}
+
+.stat_value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: rgba(56, 189, 248, 0.95);
+    z-index: 1;
+}
+
+.stat_label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(226, 232, 240, 0.72);
+    z-index: 1;
 }
 
 /* --- Content Tiles (Team, Match) --- */
@@ -263,6 +262,10 @@
     justify-content: center;
     text-align: center;
     width: 100%;
+}
+
+.info_tile {
+    min-height: 220px;
 }
 .team_name {
     font-size: 1.25rem;
@@ -294,11 +297,14 @@
 
 /* --- Navigation Tiles --- */
 .nav_tile {
+    font: inherit;
     text-align: center;
     cursor: pointer;
     justify-content: center;
     align-items: center;
     gap: 0.75rem;
+    position: relative;
+    width: 100%;
 }
 .icon {
 
@@ -308,9 +314,23 @@
     filter: drop-shadow(0 6px 12px rgba(14, 165, 233, 0.45));
 
 }
-.nav_tile:hover {
-    background: linear-gradient(160deg, rgba(56, 189, 248, 0.25), rgba(34, 197, 94, 0.25));
+.nav_tile::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(160deg, rgba(56, 189, 248, 0.18), rgba(34, 197, 94, 0.18));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
 
+.nav_tile:hover::after {
+    opacity: 1;
+}
+
+.nav_tile > * {
+    position: relative;
+    z-index: 1;
 }
 .nav_tile h4 {
     margin: 0;
@@ -329,5 +349,15 @@
 
     .profile_info {
         width: 100%;
+    }
+
+    .profile_stats {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .stat_chip {
+        flex: 1 1 calc(50% - 0.75rem);
+        justify-content: space-between;
     }
 }


### PR DESCRIPTION
## Summary
- replace the ProfileView drag-and-drop grid with a responsive CSS grid so the page no longer depends on react-grid-layout
- preserve the refreshed profile tagline and stat styling while updating navigation tiles to simple buttons that still trigger view changes
- remove the unused layout-persistence logic and associated styles, keeping only the polished tile visuals

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68de02fafcd0832ca6a119b03c81f8bc