### PR TITLE
Keep hamburger menu at top right across breakpoints

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,6 +28,7 @@ const App: React.FC = () => {
   const [view, setView] = useState<View>('PROFILE');
   const [theme, toggleTheme] = useTheme();
   const themeMode = theme === 'dark' ? 'dark' : 'light';
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
   const { currentUser, profile, loading: authLoading, login, logout, addAttendedMatch, removeAttendedMatch, updateUser } = useAuth();
 
@@ -170,13 +171,28 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen font-sans text-text app-background">
-      <Header currentView={view} setView={setView} theme={theme} toggleTheme={toggleTheme} currentUser={currentUser} />
-      <main className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8 py-10 md:py-12 pb-24 md:pb-16">
+      <Header
+        currentView={view}
+        setView={setView}
+        theme={theme}
+        currentUser={currentUser}
+        isMobileNavOpen={isMobileNavOpen}
+        onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
+      />
+      <main className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8 py-10 md:py-12 pb-16">
         <div className="space-y-8">
           {renderContent()}
         </div>
       </main>
-      <MobileNav currentView={view} setView={setView} currentUser={currentUser} />
+      <MobileNav
+        currentView={view}
+        setView={setView}
+        currentUser={currentUser}
+        isOpen={isMobileNavOpen}
+        onClose={() => setIsMobileNavOpen(false)}
+        theme={themeMode}
+        toggleTheme={toggleTheme}
+      />
       <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface/70 backdrop-blur">
         <LogoIcon className="w-12 h-12 mx-auto mb-3" theme={themeMode} />
         <p className="font-semibold text-text">The Scrum Book</p>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,8 +3,6 @@ import {
   CalendarIcon,
   InformationCircleIcon,
   TableCellsIcon,
-  SunIcon,
-  MoonIcon,
   CalendarDaysIcon,
   UserCircleIcon,
   BuildingStadiumIcon,
@@ -12,6 +10,8 @@ import {
   LocationMarkerIcon,
   UsersIcon,
   ArrowRightOnRectangleIcon,
+  MenuIcon,
+  XMarkIcon,
 } from './Icons';
 import type { View, AuthUser } from '../types';
 import styles from './Header.module.css'; // Import the CSS module
@@ -20,11 +20,12 @@ interface HeaderProps {
   currentView: View;
   setView: (view: View) => void;
   theme: string;
-  toggleTheme: () => void;
   currentUser: AuthUser | null;
+  isMobileNavOpen: boolean;
+  onMobileNavToggle: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ currentView, setView, theme, toggleTheme, currentUser }) => {
+export const Header: React.FC<HeaderProps> = ({ currentView, setView, theme, currentUser, isMobileNavOpen, onMobileNavToggle }) => {
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
 
@@ -75,49 +76,50 @@ export const Header: React.FC<HeaderProps> = ({ currentView, setView, theme, tog
   return (
     <header className={`${styles.header} ${!isVisible ? styles.header_hidden : ''}`}>
       <div className="container mx-auto flex justify-between items-center p-2">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           <LogoIcon
             className="h-10 w-auto text-primary object-contain"
             theme={theme === 'dark' ? 'dark' : 'light'}
           />
         </div>
         <div className="flex items-center gap-2 md:gap-4">
-            <nav className="hidden md:flex items-center gap-1">
-              <button
-                onClick={() => setView('PROFILE')}
-                className={`flex items-center gap-2 px-3 py-2 text-sm font-semibold transition-colors duration-200 border-b-[3px] rounded-t-sm ${
-                  isProfileActive
-                    ? 'text-primary border-primary'
-                    : 'text-text-subtle border-transparent hover:text-text hover:bg-surface-alt'
-                }`}
-              >
-                {currentUser ? (
-                  <>
-                    <UserCircleIcon className="w-5 h-5" />
-                    <span>Profile</span>
-                  </>
-                ) : (
-                  <>
-                    <ArrowRightOnRectangleIcon className="w-5 h-5" />
-                    <span>Login</span>
-                  </>
-                )}
-              </button>
-              <NavButton view="UPCOMING" label="Next 7 Days" icon={<CalendarIcon className="w-5 h-5" />} />
-              <NavButton view="NEARBY" label="Nearby" icon={<LocationMarkerIcon className="w-5 h-5" />} />
-              <NavButton view="MATCH_DAY" label="Fixtures & Results" icon={<CalendarDaysIcon className="w-5 h-5" />} />
-              <NavButton view="LEAGUE_TABLE" label="League Table" icon={<TableCellsIcon className="w-5 h-5" />} />
-              <NavButton view="GROUNDS" label="Grounds" icon={<BuildingStadiumIcon className="w-5 h-5" />} />
-              <NavButton view="COMMUNITY" label="Community" icon={<UsersIcon className="w-5 h-5" />} />
-              <NavButton view="ABOUT" label="About" icon={<InformationCircleIcon className="w-5 h-5" />} />
-            </nav>
+          <nav className="hidden md:flex items-center gap-1">
             <button
-                onClick={toggleTheme}
-                className="p-2 rounded-full text-text-subtle hover:bg-surface-alt transition-colors"
-                aria-label="Toggle theme"
+              onClick={() => setView('PROFILE')}
+              className={`flex items-center gap-2 px-3 py-2 text-sm font-semibold transition-colors duration-200 border-b-[3px] rounded-t-sm ${
+                isProfileActive
+                  ? 'text-primary border-primary'
+                  : 'text-text-subtle border-transparent hover:text-text hover:bg-surface-alt'
+              }`}
             >
-                {theme === 'dark' ? <SunIcon className="w-6 h-6" /> : <MoonIcon className="w-6 h-6" />}
+              {currentUser ? (
+                <>
+                  <UserCircleIcon className="w-5 h-5" />
+                  <span>Profile</span>
+                </>
+              ) : (
+                <>
+                  <ArrowRightOnRectangleIcon className="w-5 h-5" />
+                  <span>Login</span>
+                </>
+              )}
             </button>
+            <NavButton view="UPCOMING" label="Next 7 Days" icon={<CalendarIcon className="w-5 h-5" />} />
+            <NavButton view="NEARBY" label="Nearby" icon={<LocationMarkerIcon className="w-5 h-5" />} />
+            <NavButton view="MATCH_DAY" label="Fixtures & Results" icon={<CalendarDaysIcon className="w-5 h-5" />} />
+            <NavButton view="LEAGUE_TABLE" label="League Table" icon={<TableCellsIcon className="w-5 h-5" />} />
+            <NavButton view="GROUNDS" label="Grounds" icon={<BuildingStadiumIcon className="w-5 h-5" />} />
+            <NavButton view="COMMUNITY" label="Community" icon={<UsersIcon className="w-5 h-5" />} />
+            <NavButton view="ABOUT" label="About" icon={<InformationCircleIcon className="w-5 h-5" />} />
+          </nav>
+          <button
+            className="p-2 rounded-full text-text-subtle hover:text-text hover:bg-surface-alt transition-colors"
+            onClick={onMobileNavToggle}
+            aria-label={isMobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={isMobileNavOpen}
+          >
+            {isMobileNavOpen ? <XMarkIcon className="w-6 h-6" /> : <MenuIcon className="w-6 h-6" />}
+          </button>
         </div>
       </div>
     </header>

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -201,6 +201,12 @@ export const PencilIcon: React.FC<IconProps> = (props) => (
     </svg>
 );
 
+export const MenuIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+    </svg>
+);
+
 export const RefreshIcon: React.FC<IconProps> = (props) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 4.5v5h5" />

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -2,77 +2,211 @@ import React from 'react';
 import type { View, AuthUser } from '../types';
 import {
   CalendarIcon,
+  CalendarDaysIcon,
   TableCellsIcon,
   ListBulletIcon,
   UserCircleIcon,
   UsersIcon,
   LocationMarkerIcon,
-  ArrowRightOnRectangleIcon,
   BuildingStadiumIcon,
+  InformationCircleIcon,
+  TrophyIcon,
+  ChartBarIcon,
+  LogoIcon,
+  XMarkIcon,
+  SunIcon,
+  MoonIcon,
 } from './Icons';
 
 interface MobileNavProps {
   currentView: View;
   setView: (view: View) => void;
   currentUser: AuthUser | null;
+  isOpen: boolean;
+  onClose: () => void;
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
-const NavButton: React.FC<{
-    label: string;
-    icon: React.ReactNode;
-    isActive: boolean;
-    onClick: () => void;
-}> = ({ label, icon, isActive, onClick }) => {
-    return (
-        <button
-            onClick={onClick}
-            aria-label={label}
-            className={`flex flex-col items-center justify-center flex-1 py-2 rounded-lg transition-colors duration-200 ${
-                isActive 
-                    ? 'bg-primary/10 text-primary' 
-                    : 'text-text-subtle hover:text-text-strong hover:bg-surface-alt'
-            }`}
-        >
-            {icon}
-            <span className="text-xs font-semibold">{label}</span>
-        </button>
-    );
+type NavItem = {
+  view: View;
+  label: string;
+  description?: string;
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  isProtected?: boolean;
 };
 
+const primaryItems: NavItem[] = [
+  { view: 'UPCOMING', label: 'Next 7 Days', description: 'Quick look at the coming week', icon: CalendarIcon },
+  { view: 'NEARBY', label: 'Nearby', description: 'Matches closest to you', icon: LocationMarkerIcon },
+  { view: 'MATCH_DAY', label: 'Fixtures & Results', description: 'Full calendar of the season', icon: CalendarDaysIcon },
+  { view: 'LEAGUE_TABLE', label: 'League Table', description: 'Track club standings', icon: TableCellsIcon },
+  { view: 'GROUNDS', label: 'Grounds', description: 'Explore Super League stadiums', icon: BuildingStadiumIcon },
+  { view: 'COMMUNITY', label: 'Community', description: 'Connect with fellow supporters', icon: UsersIcon },
+  { view: 'ABOUT', label: 'About', description: 'Learn about The Scrum Book', icon: InformationCircleIcon },
+];
 
-export const MobileNav: React.FC<MobileNavProps> = ({ currentView, setView, currentUser }) => {
-    const isProfileActive = ['PROFILE', 'MY_MATCHES', 'STATS', 'BADGES', 'GROUNDS'].includes(currentView);
-    
-    const navItems: { view: View; label: string; icon: React.FC<React.SVGProps<SVGSVGElement>>; isActive: boolean }[] = [
-        { 
-            view: 'PROFILE', 
-            label: currentUser ? 'Profile' : 'Login', 
-            icon: currentUser ? UserCircleIcon : ArrowRightOnRectangleIcon, 
-            isActive: isProfileActive 
-        },
-        { view: 'UPCOMING', label: 'Upcoming', icon: CalendarIcon, isActive: currentView === 'UPCOMING' },
-        { view: 'MATCH_DAY', label: 'Fixtures', icon: ListBulletIcon, isActive: currentView === 'MATCH_DAY' },
-        { view: 'LEAGUE_TABLE', label: 'Table', icon: TableCellsIcon, isActive: currentView === 'LEAGUE_TABLE' },
-        { view: 'GROUNDS', label: 'Grounds', icon: BuildingStadiumIcon, isActive: currentView === 'GROUNDS' },
-        { view: 'COMMUNITY', label: 'Community', icon: UsersIcon, isActive: currentView === 'COMMUNITY' },
-    ];
+const supporterItems: NavItem[] = [
+  { view: 'MY_MATCHES', label: 'My Matches', description: 'Your attended fixtures', icon: ListBulletIcon, isProtected: true },
+  { view: 'STATS', label: 'My Stats', description: 'Personal supporter insights', icon: ChartBarIcon, isProtected: true },
+  { view: 'BADGES', label: 'Badges', description: 'Earned supporter milestones', icon: TrophyIcon, isProtected: true },
+  { view: 'PROFILE', label: 'Profile', description: 'Manage your supporter profile', icon: UserCircleIcon, isProtected: true },
+];
 
-    return (
-        <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-surface shadow-lg z-20 border-t border-border">
-            <div className="flex justify-around items-center h-16 gap-1 px-1">
-                {navItems.map(item => {
-                    const Icon = item.icon;
-                    return (
-                        <NavButton
-                            key={item.view}
-                            label={item.label}
-                            isActive={item.isActive}
-                            onClick={() => setView(item.view)}
-                            icon={<Icon className="w-6 h-6 mb-1" />}
-                        />
-                    );
-                })}
+export const MobileNav: React.FC<MobileNavProps> = ({ currentView, setView, currentUser, isOpen, onClose, theme, toggleTheme }) => {
+  const handleNavigate = (view: View) => {
+    setView(view);
+    onClose();
+  };
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-30 bg-black/60 backdrop-blur-sm transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'pointer-events-none opacity-0'
+        }`}
+        onClick={onClose}
+        aria-hidden={!isOpen}
+      />
+      <nav
+        className={`fixed inset-y-0 left-0 z-40 w-80 max-w-[calc(100%-4rem)] transform bg-surface border-r border-border shadow-2xl transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+        aria-hidden={!isOpen}
+        aria-label="Mobile navigation"
+      >
+        <div className="flex items-center justify-between px-5 py-5 border-b border-border/70 bg-surface-alt/60 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <LogoIcon className="h-10 w-10" theme={theme} />
+            <div className="flex flex-col">
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+              <span className="text-lg font-heading text-text-strong">Matchday Companion</span>
             </div>
-        </nav>
-    );
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 text-text-subtle transition-colors hover:bg-surface hover:text-text"
+            aria-label="Close navigation menu"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="px-5 py-6 space-y-6 overflow-y-auto h-full pb-24">
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle mb-4">Main Navigation</h2>
+            <ul className="space-y-2">
+              {primaryItems.map(({ view, label, description, icon: Icon }) => {
+                const isActive = currentView === view;
+                return (
+                  <li key={view}>
+                    <button
+                      onClick={() => handleNavigate(view)}
+                      className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
+                        isActive
+                          ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
+                          : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
+                            isActive
+                              ? 'border-primary/40 bg-primary/20 text-primary'
+                              : 'border-border/70 bg-surface text-text-subtle'
+                          }`}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </span>
+                        <div>
+                          <p className="font-heading text-lg text-text-strong">{label}</p>
+                          {description && <p className="text-xs text-text-subtle">{description}</p>}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle mb-4">Supporter Hub</h2>
+            <ul className="space-y-2">
+              {supporterItems.map(({ view, label, description, icon: Icon, isProtected }) => {
+                const isActive = currentView === view;
+                const disabled = isProtected && !currentUser;
+                return (
+                  <li key={view}>
+                    <button
+                      onClick={() => !disabled && handleNavigate(view)}
+                      className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
+                        disabled
+                          ? 'cursor-not-allowed border-border/40 bg-surface-alt/30 text-text-subtle'
+                          : isActive
+                            ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
+                            : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                      }`}
+                      aria-disabled={disabled}
+                    >
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
+                            isActive
+                              ? 'border-primary/40 bg-primary/20 text-primary'
+                              : 'border-border/70 bg-surface text-text-subtle'
+                          }`}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </span>
+                        <div>
+                          <p className="font-heading text-lg text-text-strong">{label}</p>
+                          {description && <p className="text-xs text-text-subtle">{description}</p>}
+                          {disabled && (
+                            <p className="text-[11px] font-medium text-danger mt-1">Login required</p>
+                          )}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div className="rounded-xl border border-border/70 bg-surface-alt/40 px-4 py-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-heading text-lg text-text-strong">Appearance</p>
+                <p className="text-xs text-text-subtle">Switch between light and dark themes</p>
+              </div>
+              <button
+                onClick={toggleTheme}
+                className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface px-3 py-2 text-sm font-semibold text-text-subtle transition-colors hover:text-text hover:border-border"
+                aria-label="Toggle theme"
+              >
+                {theme === 'dark' ? (
+                  <>
+                    <SunIcon className="h-4 w-4" />
+                    <span>Light</span>
+                  </>
+                ) : (
+                  <>
+                    <MoonIcon className="h-4 w-4" />
+                    <span>Dark</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border/60 bg-surface-alt/60 px-4 py-4 text-sm text-text-subtle">
+            <p className="font-heading text-text-strong text-lg">Matchday Tip</p>
+            <p className="mt-2">
+              Keep your supporter log up to date to unlock new badges and season-long stats. Tap “My Matches” after every game you attend.
+            </p>
+          </div>
+        </div>
+      </nav>
+    </>
+  );
 };

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>The Scrum Book - Your Rugby League Companion</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/super-league">
     <style>
       :root {
         color-scheme: light; /* Defaulting to dark, but 'light' is a fallback */
@@ -26,6 +27,7 @@
         --gradient-1: linear-gradient(140deg, rgba(226, 24, 54, 0.15), rgba(0, 82, 204, 0.1));
         --gradient-2: radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.1), transparent 55%);
         --gradient-3: radial-gradient(circle at 80% 0%, rgba(226, 24, 54, 0.12), transparent 45%);
+        --font-heading: "Super League", "Inter", sans-serif;
       }
       html.dark {
          color-scheme: dark;
@@ -44,6 +46,7 @@
       }
       body {
         background: var(--clr-surface-alt);
+        font-family: 'Inter', system-ui, sans-serif;
       }
       .app-background {
         background-color: var(--clr-surface-alt);
@@ -54,6 +57,14 @@
       html.dark .app-background {
         background-color: #161719;
         background-image: var(--gradient-1), var(--gradient-2), var(--gradient-3);
+      }
+
+      h1, h2, h3, h4 {
+        font-family: var(--font-heading);
+        font-weight: 700;
+      }
+      .font-heading {
+        font-family: var(--font-heading);
       }
     </style>
     <script>
@@ -86,6 +97,7 @@
             },
             fontFamily: {
               sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+              heading: ['"Super League"', 'Inter', 'sans-serif']
             },
           }
         }


### PR DESCRIPTION
## Summary
- remove the standalone desktop theme toggle and keep the hamburger trigger visible beside navigation across all screen sizes
- allow the drawer overlay and panel to render on larger breakpoints so the header control works consistently
- simplify Header props now that theme changes are handled exclusively from the menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2382655c832c8032d6abdffe3796