### PR TITLE
Adjust profile stats layout

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -162,9 +162,17 @@
 }
 
 /* Stat Cards */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  grid-column: 1 / -1;
+}
+
 .statCard {
     text-align: center;
-    gap: 0.25rem;
+    gap: 0.5rem;
+    padding-block: clamp(1.5rem, 5vw, 2.25rem);
 }
 .statValue {
     font-size: clamp(2rem, 5vw, 2.5rem);

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -119,18 +119,20 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
         </section>
 
         {/* Stats Tiles */}
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{attendedMatches.length}</h2>
-            <p className={styles.statLabel}>Matches Attended</p>
-        </section>
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{earnedBadgeIds.length}</h2>
-            <p className={styles.statLabel}>Badges Unlocked</p>
-        </section>
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{new Set(attendedMatches.map(am => am.match.venue)).size}</h2>
-            <p className={styles.statLabel}>Grounds Visited</p>
-        </section>
+        <div className={styles.statGrid}>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{attendedMatches.length}</h2>
+              <p className={styles.statLabel}>Matches Attended</p>
+          </section>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{earnedBadgeIds.length}</h2>
+              <p className={styles.statLabel}>Badges Unlocked</p>
+          </section>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{new Set(attendedMatches.map(am => am.match.venue)).size}</h2>
+              <p className={styles.statLabel}>Grounds Visited</p>
+          </section>
+        </div>
 
 
         {/* My Team Tile */}


### PR DESCRIPTION
## Summary
- arrange the profile stats within a three-column grid for a more dynamic layout
- increase padding inside stat cards to give the content extra breathing room

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de62ebcb3c832c942ecf37df7fa6fe