### PR TITLE
Improve profile contrast and team branding

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -150,34 +150,50 @@
 }
 
 .profileTagline {
-  display: inline-block;
-  margin-top: 0.5rem;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-top: 0.75rem;
+  padding: 0.4rem 0.95rem;
+  font-size: 0.9rem;
   font-weight: 600;
   border-radius: 9999px;
-  background: var(--clr-primary-light);
-  color: var(--clr-primary);
-  background-color: var(--clr-primary-light);
+  background: linear-gradient(135deg, rgba(255, 77, 109, 0.25), rgba(0, 116, 255, 0.22));
+  color: var(--clr-primary-bright);
+  box-shadow: 0 0 0 1px rgba(255, 77, 109, 0.35);
+}
+
+.taglineIcon {
+  width: 1rem;
+  height: 1rem;
+  color: inherit;
 }
 
 /* Stat Cards */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  grid-column: 1 / -1;
+}
+
 .statCard {
     text-align: center;
-    gap: 0.25rem;
+    gap: 0.5rem;
+    padding-block: clamp(1.5rem, 5vw, 2.25rem);
+    background-image: linear-gradient(180deg, rgba(255, 77, 109, 0.14), rgba(255, 77, 109, 0));
 }
 .statValue {
     font-size: clamp(2rem, 5vw, 2.5rem);
     font-weight: 800;
-    color: var(--clr-primary);
+    color: var(--clr-primary-bright);
     line-height: 1;
+    text-shadow: 0 0 18px rgba(255, 77, 109, 0.3);
 }
 .statLabel {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
+    font-size: 0.875rem;
+    font-weight: 500;
     color: var(--clr-text-subtle);
-    letter-spacing: 0.05em;
 }
 
 

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -9,6 +9,7 @@ import {
   ChartBarIcon,
   ListBulletIcon,
   PencilIcon,
+  SparklesIcon,
   TrophyIcon,
   UserCircleIcon,
 } from './Icons';
@@ -113,24 +114,29 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                   {user.name} <PencilIcon className={styles.editNameIcon} />
                 </h1>
               )}
-              <span className={styles.profileTagline}>{profileTagline}</span>
+              <span className={styles.profileTagline}>
+                <SparklesIcon className={styles.taglineIcon} aria-hidden="true" />
+                {profileTagline}
+              </span>
             </div>
           </div>
         </section>
 
         {/* Stats Tiles */}
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{attendedMatches.length}</h2>
-            <p className={styles.statLabel}>Matches Attended</p>
-        </section>
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{earnedBadgeIds.length}</h2>
-            <p className={styles.statLabel}>Badges Unlocked</p>
-        </section>
-        <section className={`${styles.dashboardCard} ${styles.statCard}`}>
-            <h2 className={styles.statValue}>{new Set(attendedMatches.map(am => am.match.venue)).size}</h2>
-            <p className={styles.statLabel}>Grounds Visited</p>
-        </section>
+        <div className={styles.statGrid}>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{attendedMatches.length}</h2>
+              <p className={styles.statLabel}>Matches Attended</p>
+          </section>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{earnedBadgeIds.length}</h2>
+              <p className={styles.statLabel}>Badges Unlocked</p>
+          </section>
+          <section className={`${styles.dashboardCard} ${styles.statCard}`}>
+              <h2 className={styles.statValue}>{new Set(attendedMatches.map(am => am.match.venue)).size}</h2>
+              <p className={styles.statLabel}>Grounds Visited</p>
+          </section>
+        </div>
 
 
         {/* My Team Tile */}

--- a/components/TeamLogo.tsx
+++ b/components/TeamLogo.tsx
@@ -19,7 +19,7 @@ const getInitials = (name: string): string => {
         .toUpperCase();
 };
 
-export const TeamLogo: React.FC<TeamLogoProps> = ({ teamId, teamName, size = 'medium', className }) => {
+export const TeamLogo: React.FC<TeamLogoProps> = ({ teamId, teamName, size = 'medium', className = '' }) => {
     const sizeClasses = {
         small: 'w-6 h-6',
         medium: 'w-10 h-10 md:w-12 md:h-12',
@@ -31,14 +31,27 @@ export const TeamLogo: React.FC<TeamLogoProps> = ({ teamId, teamName, size = 'me
     };
     
     const initials = getInitials(teamName);
-    const branding = TEAM_BRANDING[teamId] || { bg: '#6B7280', text: '#FFFFFF' }; // Default to grey if no ID match
+    const branding = TEAM_BRANDING[teamId] || {
+        bg: '#6B7280',
+        text: '#FFFFFF',
+        palette: ['#6B7280', '#9CA3AF'],
+    }; // Default palette if no ID match
+    const palette = branding.palette ?? [branding.bg, branding.bg];
+    const background =
+        palette.length > 1
+            ? `linear-gradient(135deg, ${palette[0]}, ${palette[1]})`
+            : branding.bg;
+    const outline = palette.length > 2 ? palette[2] : 'rgba(255, 255, 255, 0.24)';
 
     return (
-        <div 
-            className={`rounded-full flex items-center justify-center overflow-hidden flex-shrink-0 border border-black/10 dark:border-white/10 ${sizeClasses[size]} ${className}`}
-            style={{ backgroundColor: branding.bg }}
+        <div
+            className={`rounded-full flex items-center justify-center overflow-hidden flex-shrink-0 ${sizeClasses[size]} ${className}`}
+            style={{
+                background,
+                boxShadow: `0 0 0 1px ${outline}`,
+            }}
         >
-            <span 
+            <span
                 className={`font-bold select-none ${textSizeClasses[size]}`}
                 style={{ color: branding.text }}
             >

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       :root {
         color-scheme: light;
         --clr-primary: #E21836;
+        --clr-primary-bright: #FF4D6D;
         --clr-secondary: #FFD447;
         --clr-accent: #0074FF;
         --clr-danger: #E21836;
@@ -32,6 +33,7 @@
       html.dark {
         color-scheme: dark;
         --clr-primary: #E21836; /* Super League Red */
+        --clr-primary-bright: #FF4D6D;
         --clr-secondary: #FFDD57;
         --clr-accent: #0074FF;
         --clr-surface: #1F2023;


### PR DESCRIPTION
## Summary
- brighten the profile tagline and stats cards with higher-contrast accent styling using the new primary-bright token
- update stat values to pop against the dark surface while keeping labels subtle for readability
- render favourite team initials with gradients derived from each club palette for on-brand visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de62ebcb3c832c942ecf37df7fa6fe