### PR TITLE
Lighten default text colors for better contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
         --clr-info: #0052CC;
         --clr-success: #00A86B;
         --clr-text-strong: #FFFFFF;
-        --clr-text: #E0E0E0;
-        --clr-text-subtle: #A0A0A0;
+        --clr-text: #F3F4F6;
+        --clr-text-subtle: #CDD2D9;
         --clr-border: #404040;
         --clr-surface: #1F2023;
         --clr-surface-alt: #161719;
@@ -39,8 +39,8 @@
         --clr-surface: #1F2023;
         --clr-surface-alt: #161719;
         --clr-text-strong: #FFFFFF;
-        --clr-text: #E0E0E0;
-        --clr-text-subtle: #A0A0A0;
+        --clr-text: #F3F4F6;
+        --clr-text-subtle: #CDD2D9;
         --clr-border: #404040;
         --gradient-1: linear-gradient(140deg, rgba(226, 24, 54, 0.2), rgba(0, 116, 255, 0.15));
         --gradient-2: radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.18), transparent 60%);


### PR DESCRIPTION
## Summary
- brighten the global text and subtle text color tokens to improve readability against the dark background in both themes

## Testing
- npm run build *(fails: existing TS2322 type mismatch in AuthContext)*

------
https://chatgpt.com/codex/tasks/task_e_68de7e1a2d4c832c9ffa19b59e431786