### PR TITLE
Hide desktop header and add floating menu toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,7 @@ import { NearbyMatchesView } from './components/NearbyMatchesView';
 import { DataUploader } from './components/DataUploader';
 import { CommunityView } from './components/CommunityView';
 import { LoginPromptView } from './components/LoginPromptView';
-import { LogoIcon } from './components/Icons';
+import { LogoIcon, MenuIcon } from './components/Icons';
 import { syncThemeWithFavouriteTeam } from './utils/themeUtils';
 
 const App: React.FC = () => {
@@ -179,6 +179,15 @@ const App: React.FC = () => {
         isMobileNavOpen={isMobileNavOpen}
         onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
       />
+      <button
+        type="button"
+        className="hidden md:flex fixed top-6 right-6 z-20 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
+        onClick={() => setIsMobileNavOpen(true)}
+        aria-label="Open navigation menu"
+      >
+        <MenuIcon className="w-5 h-5" />
+        <span>Menu</span>
+      </button>
       <main className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8 py-10 md:py-12 pb-16">
         <div className="space-y-8">
           {renderContent()}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -74,7 +74,7 @@ export const Header: React.FC<HeaderProps> = ({ currentView, setView, theme, cur
   const isProfileActive = ['PROFILE', 'MY_MATCHES', 'STATS', 'BADGES', 'GROUNDS', 'ADMIN'].includes(currentView);
 
   return (
-    <header className={`${styles.header} ${!isVisible ? styles.header_hidden : ''}`}>
+    <header className={`${styles.header} ${!isVisible ? styles.header_hidden : ''} md:hidden`}>
       <div className="container mx-auto flex justify-between items-center p-2">
         <div className="flex items-center gap-2">
           <LogoIcon


### PR DESCRIPTION
## Summary
- hide the sticky header on medium+ viewports so the desktop experience no longer shows the top bar
- add a floating menu button on desktop to keep the slide-out navigation accessible

## Testing
- npm run build *(fails: existing type mismatch in contexts/AuthContext.tsx around avatarSource)*

------
https://chatgpt.com/codex/tasks/task_e_68deb3b9b4ec832ca36ef23eafc8b0eb