### PR TITLE
Rework mobile header into floating controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -172,10 +172,8 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen font-sans text-text app-background">
       <Header
-        currentView={view}
         setView={setView}
         theme={theme}
-        currentUser={currentUser}
         isMobileNavOpen={isMobileNavOpen}
         onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
       />

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -1,13 +1,53 @@
-.header {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    transition: top 0.3s ease-in-out;
-    background-color: var(--clr-surface);
-    box-shadow: 0 1px 2px rgba(0,0,0,.08);
-    border-bottom: 1px solid var(--clr-border);
+.logoButton {
+  position: fixed;
+  top: 1.25rem;
+  left: 1.25rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
 }
 
-.header_hidden {
-    top: -100px; /* Moves the header off-screen */
+.logoIcon {
+  width: 3.75rem;
+  height: 3.75rem;
+}
+
+.menuButton {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(15, 23, 42, 0.88);
+  color: #ffffff;
+  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.75);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  cursor: pointer;
+}
+
+.menuButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px -18px rgba(15, 23, 42, 0.85);
+}
+
+.menuIcon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.logoButton:focus-visible,
+.menuButton:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 3px;
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,127 +1,42 @@
-import React, { useState, useEffect } from 'react';
-import {
-  CalendarIcon,
-  InformationCircleIcon,
-  TableCellsIcon,
-  CalendarDaysIcon,
-  UserCircleIcon,
-  BuildingStadiumIcon,
-  LogoIcon,
-  LocationMarkerIcon,
-  UsersIcon,
-  ArrowRightOnRectangleIcon,
-  MenuIcon,
-  XMarkIcon,
-} from './Icons';
-import type { View, AuthUser } from '../types';
-import styles from './Header.module.css'; // Import the CSS module
+import React from 'react';
+import { LogoIcon, MenuIcon, XMarkIcon } from './Icons';
+import type { View } from '../types';
+import styles from './Header.module.css';
 
 interface HeaderProps {
-  currentView: View;
   setView: (view: View) => void;
   theme: string;
-  currentUser: AuthUser | null;
   isMobileNavOpen: boolean;
   onMobileNavToggle: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ currentView, setView, theme, currentUser, isMobileNavOpen, onMobileNavToggle }) => {
-  const [isVisible, setIsVisible] = useState(true);
-  const [lastScrollY, setLastScrollY] = useState(0);
-
-  useEffect(() => {
-    const controlNavbar = () => {
-      if (typeof window !== 'undefined') {
-        if (window.scrollY > lastScrollY && window.scrollY > 80) { // If scrolling down and past 80px
-          setIsVisible(false);
-        } else { // If scrolling up
-          setIsVisible(true);
-        }
-        setLastScrollY(window.scrollY);
-      }
-    };
-
-    if (typeof window !== 'undefined') {
-      window.addEventListener('scroll', controlNavbar);
-      return () => {
-        window.removeEventListener('scroll', controlNavbar);
-      };
-    }
-  }, [lastScrollY]);
-
-
-  const NavButton: React.FC<{
-    view: View;
-    label: string;
-    icon: React.ReactNode;
-  }> = ({ view, label, icon }) => {
-    const isActive = currentView === view;
-    return (
-      <button
-        onClick={() => setView(view)}
-        className={`flex items-center gap-2 px-3 py-2 text-sm font-semibold transition-colors duration-200 border-b-[3px] rounded-t-sm ${
-          isActive
-            ? 'text-primary border-primary'
-            : 'text-text-subtle border-transparent hover:text-text hover:bg-surface-alt'
-        }`}
-      >
-        {icon}
-        <span>{label}</span>
-      </button>
-    );
-  };
-
-  const isProfileActive = ['PROFILE', 'MY_MATCHES', 'STATS', 'BADGES', 'GROUNDS', 'ADMIN'].includes(currentView);
+export const Header: React.FC<HeaderProps> = (props) => {
+  const { setView, theme, isMobileNavOpen, onMobileNavToggle } = props;
+  const themeMode = theme === 'dark' ? 'dark' : 'light';
 
   return (
-    <header className={`${styles.header} ${!isVisible ? styles.header_hidden : ''} md:hidden`}>
-      <div className="container mx-auto flex justify-between items-center p-2">
-        <div className="flex items-center gap-2">
-          <LogoIcon
-            className="h-10 w-auto text-primary object-contain"
-            theme={theme === 'dark' ? 'dark' : 'light'}
-          />
-        </div>
-        <div className="flex items-center gap-2 md:gap-4">
-          <nav className="hidden md:flex items-center gap-1">
-            <button
-              onClick={() => setView('PROFILE')}
-              className={`flex items-center gap-2 px-3 py-2 text-sm font-semibold transition-colors duration-200 border-b-[3px] rounded-t-sm ${
-                isProfileActive
-                  ? 'text-primary border-primary'
-                  : 'text-text-subtle border-transparent hover:text-text hover:bg-surface-alt'
-              }`}
-            >
-              {currentUser ? (
-                <>
-                  <UserCircleIcon className="w-5 h-5" />
-                  <span>Profile</span>
-                </>
-              ) : (
-                <>
-                  <ArrowRightOnRectangleIcon className="w-5 h-5" />
-                  <span>Login</span>
-                </>
-              )}
-            </button>
-            <NavButton view="UPCOMING" label="Next 7 Days" icon={<CalendarIcon className="w-5 h-5" />} />
-            <NavButton view="NEARBY" label="Nearby" icon={<LocationMarkerIcon className="w-5 h-5" />} />
-            <NavButton view="MATCH_DAY" label="Fixtures & Results" icon={<CalendarDaysIcon className="w-5 h-5" />} />
-            <NavButton view="LEAGUE_TABLE" label="League Table" icon={<TableCellsIcon className="w-5 h-5" />} />
-            <NavButton view="GROUNDS" label="Grounds" icon={<BuildingStadiumIcon className="w-5 h-5" />} />
-            <NavButton view="COMMUNITY" label="Community" icon={<UsersIcon className="w-5 h-5" />} />
-            <NavButton view="ABOUT" label="About" icon={<InformationCircleIcon className="w-5 h-5" />} />
-          </nav>
-          <button
-            className="p-2 rounded-full text-text-subtle hover:text-text hover:bg-surface-alt transition-colors"
-            onClick={onMobileNavToggle}
-            aria-label={isMobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'}
-            aria-expanded={isMobileNavOpen}
-          >
-            {isMobileNavOpen ? <XMarkIcon className="w-6 h-6" /> : <MenuIcon className="w-6 h-6" />}
-          </button>
-        </div>
-      </div>
-    </header>
+    <>
+      <button
+        type="button"
+        className={`md:hidden ${styles.logoButton}`}
+        onClick={() => setView('PROFILE')}
+        aria-label="Go to profile"
+      >
+        <LogoIcon className={styles.logoIcon} theme={themeMode} />
+      </button>
+      <button
+        type="button"
+        className={`md:hidden ${styles.menuButton}`}
+        onClick={onMobileNavToggle}
+        aria-label={isMobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'}
+        aria-expanded={isMobileNavOpen}
+      >
+        {isMobileNavOpen ? (
+          <XMarkIcon className={styles.menuIcon} />
+        ) : (
+          <MenuIcon className={styles.menuIcon} />
+        )}
+      </button>
+    </>
   );
 };

--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -238,9 +238,13 @@
   position: relative;
   margin-top: clamp(-5.5rem, -9vw, -6.5rem);
   padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 5vw, 3rem) 3.5rem;
+}
+
+.summaryGrid {
   display: grid;
   gap: clamp(1.5rem, 4vw, 2.5rem);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
 }
 
 .detailCard {
@@ -325,11 +329,28 @@
   color: var(--text-subtle);
 }
 
+.actionCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .quickActions {
-  grid-column: 1 / -1;
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.quickActionsRail {
+  position: relative;
+}
+
+.quickActionsRail::-webkit-scrollbar {
+  display: none;
+}
+
+.quickActionsRail {
+  scrollbar-width: none;
 }
 
 .quickActions button {
@@ -367,11 +388,76 @@
 
   .mainContent {
     margin-top: -4.5rem;
-    grid-template-columns: 1fr;
+  }
+
+  .summaryGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'team team'
+      'match quick';
+    gap: 1.25rem;
+  }
+
+  .myTeamCard {
+    grid-area: team;
+  }
+
+  .lastMatchCard {
+    grid-area: match;
+  }
+
+  .actionCard {
+    grid-area: quick;
+  }
+
+  .detailCard {
+    padding: 1.25rem;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
   .cardBody {
     flex-direction: column;
     align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .teamSummary {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .teamLogoSummary {
+    width: 48px !important;
+    height: 48px !important;
+  }
+
+  .quickActions {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(150px, 1fr);
+    overflow-x: auto;
+    padding-bottom: 0.35rem;
+    margin: 0 -0.35rem;
+    padding-left: 0.35rem;
+    scroll-snap-type: x mandatory;
+  }
+
+  .quickActions button {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 1rem 1.15rem;
+    scroll-snap-align: start;
+  }
+
+  .quickActions svg {
+    width: 24px;
+    height: 24px;
   }
 }

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -164,72 +164,79 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
         </section>
 
         <main className={styles.mainContent}>
-          <section className={styles.detailCard}>
-            <header className={styles.cardHeader}>
-              <h2>My Team</h2>
-              <button type="button" onClick={() => setIsTeamModalOpen(true)}>
-                {favoriteTeam ? 'Change Team' : 'Select Team'}
-              </button>
-            </header>
-            <div className={styles.cardBody}>
-              {favoriteTeam ? (
-                <div className={styles.teamSummary}>
-                  <TeamLogo
-                    teamId={favoriteTeam.id}
-                    teamName={favoriteTeam.name}
-                    className={styles.teamLogoSummary}
-                  />
-                  <span>{favoriteTeam.name}</span>
-                </div>
-              ) : (
-                <p>No favorite team selected yet.</p>
-              )}
-            </div>
-          </section>
+          <div className={styles.summaryGrid}>
+            <section className={`${styles.detailCard} ${styles.myTeamCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>My Team</h2>
+                <button type="button" onClick={() => setIsTeamModalOpen(true)}>
+                  {favoriteTeam ? 'Change Team' : 'Select Team'}
+                </button>
+              </header>
+              <div className={styles.cardBody}>
+                {favoriteTeam ? (
+                  <div className={styles.teamSummary}>
+                    <TeamLogo
+                      teamId={favoriteTeam.id}
+                      teamName={favoriteTeam.name}
+                      className={styles.teamLogoSummary}
+                    />
+                    <span>{favoriteTeam.name}</span>
+                  </div>
+                ) : (
+                  <p>No favorite team selected yet.</p>
+                )}
+              </div>
+            </section>
 
-          <section className={styles.detailCard}>
-            <header className={styles.cardHeader}>
-              <h2>Last Match</h2>
-            </header>
-            <div className={styles.cardBody}>
-              {recentMatch ? (
-                <div className={styles.matchSummary}>
-                  <p>{`${recentMatch.match.homeTeam.name} vs ${recentMatch.match.awayTeam.name}`}</p>
-                  <span className={styles.matchScore}>{`${recentMatch.match.scores.home} - ${recentMatch.match.scores.away}`}</span>
-                  <span className={styles.matchMeta}>
-                    {recentMatch.match.venue}
-                    {' · '}
-                    {new Date(recentMatch.attendedOn).toLocaleDateString()}
-                  </span>
-                </div>
-              ) : (
-                <p>No matches attended yet.</p>
-              )}
-            </div>
-          </section>
+            <section className={`${styles.detailCard} ${styles.lastMatchCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>Last Match</h2>
+              </header>
+              <div className={styles.cardBody}>
+                {recentMatch ? (
+                  <div className={styles.matchSummary}>
+                    <p>{`${recentMatch.match.homeTeam.name} vs ${recentMatch.match.awayTeam.name}`}</p>
+                    <span className={styles.matchScore}>{`${recentMatch.match.scores.home} - ${recentMatch.match.scores.away}`}</span>
+                    <span className={styles.matchMeta}>
+                      {recentMatch.match.venue}
+                      {' · '}
+                      {new Date(recentMatch.attendedOn).toLocaleDateString()}
+                    </span>
+                  </div>
+                ) : (
+                  <p>No matches attended yet.</p>
+                )}
+              </div>
+            </section>
 
-          <nav className={styles.quickActions} aria-label="Profile navigation">
-            <button type="button" onClick={() => setView('MY_MATCHES')}>
-              <ListBulletIcon aria-hidden="true" />
-              <span>My Matches</span>
-            </button>
-            <button type="button" onClick={() => setView('BADGES')}>
-              <TrophyIcon aria-hidden="true" />
-              <span>Badges</span>
-            </button>
-            <button type="button" onClick={() => setView('ADMIN')}>
-              <UserCircleIcon aria-hidden="true" />
-              <span>Admin Tools</span>
-            </button>
-            <button type="button" onClick={() => setView('STATS')}>
-              <ChartBarIcon aria-hidden="true" />
-              <span>My Stats</span>
-            </button>
-            <button type="button" onClick={onLogout}>
-              <ArrowRightOnRectangleIcon aria-hidden="true" />
-              <span>Logout</span>
-            </button>
-          </nav>
+            <section className={`${styles.detailCard} ${styles.actionCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>Quick Links</h2>
+              </header>
+              <nav className={`${styles.quickActions} ${styles.quickActionsRail}`} aria-label="Profile navigation">
+                <button type="button" onClick={() => setView('MY_MATCHES')}>
+                  <ListBulletIcon aria-hidden="true" />
+                  <span>My Matches</span>
+                </button>
+                <button type="button" onClick={() => setView('BADGES')}>
+                  <TrophyIcon aria-hidden="true" />
+                  <span>Badges</span>
+                </button>
+                <button type="button" onClick={() => setView('ADMIN')}>
+                  <UserCircleIcon aria-hidden="true" />
+                  <span>Admin Tools</span>
+                </button>
+                <button type="button" onClick={() => setView('STATS')}>
+                  <ChartBarIcon aria-hidden="true" />
+                  <span>My Stats</span>
+                </button>
+                <button type="button" onClick={onLogout}>
+                  <ArrowRightOnRectangleIcon aria-hidden="true" />
+                  <span>Logout</span>
+                </button>
+              </nav>
+            </section>
+          </div>
         </main>
       </div>
 


### PR DESCRIPTION
## Summary
- replace the mobile top bar with fixed floating logo and menu controls
- enlarge the logo and restyle the burger toggle as a circular action button
- update the header usage to match the simplified props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded2e36de0832ca74a1ca76b290cb0