### PR TITLE
Add mounted profile hero logo

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -46,6 +46,66 @@
   flex-wrap: wrap;
 }
 
+.logoMount {
+  position: relative;
+  margin-left: auto;
+  padding: clamp(0.9rem, 2vw, 1.1rem) clamp(1.7rem, 3.5vw, 2.6rem);
+  border-radius: 140px;
+  background: radial-gradient(ellipse at top, rgba(255, 250, 240, 0.96) 0%, rgba(247, 225, 188, 0.96) 60%, rgba(238, 203, 152, 0.96) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow:
+    0 22px 38px -24px rgba(5, 16, 45, 0.9),
+    0 18px 30px -18px rgba(12, 19, 48, 0.55),
+    inset 0 10px 22px rgba(255, 255, 255, 0.55),
+    inset 0 -14px 24px rgba(214, 168, 109, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: clamp(150px, 32vw, 190px);
+  z-index: 1;
+  transition: transform 0.22s ease, box-shadow 0.22s ease;
+}
+
+.logoMount::before {
+  content: '';
+  position: absolute;
+  inset: -18px 10px 16px;
+  border-radius: 160px;
+  background: rgba(7, 13, 34, 0.65);
+  filter: blur(24px);
+  opacity: 0.55;
+  z-index: -1;
+}
+
+.logoMount:hover {
+  transform: translateY(-3px);
+  box-shadow:
+    0 26px 44px -26px rgba(5, 16, 45, 0.95),
+    0 22px 32px -18px rgba(12, 19, 48, 0.65),
+    inset 0 12px 22px rgba(255, 255, 255, 0.6),
+    inset 0 -14px 26px rgba(214, 168, 109, 0.45);
+}
+
+.logoMountIcon {
+  width: clamp(3.75rem, 9vw, 4.75rem);
+  height: clamp(3.75rem, 9vw, 4.75rem);
+  display: block;
+  filter: drop-shadow(0 8px 14px rgba(0, 0, 0, 0.22));
+}
+
+@media (max-width: 768px) {
+  .logoMount {
+    margin-top: 0.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .logoMount {
+    order: -1;
+    margin-bottom: 0.75rem;
+  }
+}
+
 .avatarWrap {
   position: relative;
   width: clamp(96px, 18vw, 120px);

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -8,6 +8,7 @@ import {
   BuildingStadiumIcon,
   ChartBarIcon,
   ListBulletIcon,
+  LogoIcon,
   PencilIcon,
   SparklesIcon,
   TrophyIcon,
@@ -140,6 +141,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                     {favoriteTeam.name}
                   </span>
                 )}
+              </div>
+              <div className={styles.logoMount}>
+                <LogoIcon className={styles.logoMountIcon} theme="light" />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- mount The Scrum Book logo within the profile hero alongside the user identity area
- add cream oval styling and drop-shadow polish so the logo feels raised and responsive across breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dee2b8af98832cb2de22eb34deb275