### PR TITLE
Add email-based authentication flow with multi-screen login UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,7 +30,19 @@ const App: React.FC = () => {
   const themeMode = theme === 'dark' ? 'dark' : 'light';
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
-  const { currentUser, profile, loading: authLoading, login, logout, addAttendedMatch, removeAttendedMatch, updateUser } = useAuth();
+  const {
+    currentUser,
+    profile,
+    loading: authLoading,
+    login,
+    loginWithCredentials,
+    signup,
+    requestPasswordReset,
+    logout,
+    addAttendedMatch,
+    removeAttendedMatch,
+    updateUser,
+  } = useAuth();
 
   const [matches, setMatches] = useState<Match[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -92,7 +104,15 @@ const App: React.FC = () => {
 
     const protectedViews: View[] = ['MY_MATCHES', 'STATS', 'BADGES', 'PROFILE', 'COMMUNITY', 'ADMIN'];
     if (!currentUser && protectedViews.includes(view)) {
-      return <LoginPromptView onLogin={login} theme={themeMode} />;
+      return (
+        <LoginPromptView
+          onLogin={login}
+          onEmailLogin={loginWithCredentials}
+          onSignup={signup}
+          onPasswordReset={requestPasswordReset}
+          theme={themeMode}
+        />
+      );
     }
 
     // While authenticating, show a spinner for protected views

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -194,6 +194,13 @@ export const MiniSpinnerIcon: React.FC<IconProps> = (props) => (
     </svg>
 );
 
+export const EnvelopeIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75l8.954 5.373a1.5 1.5 0 001.592 0L21.75 6.75" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.5h16.5A1.5 1.5 0 0121.75 6v12a1.5 1.5 0 01-1.5 1.5H3.75A1.5 1.5 0 012.25 18V6a1.5 1.5 0 011.5-1.5z" />
+    </svg>
+);
+
 export const PencilIcon: React.FC<IconProps> = (props) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 3.487a1.5 1.5 0 012.121 0l1.53 1.53a1.5 1.5 0 010 2.121l-9.19 9.19-3.712.742.742-3.712z" />

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -1,62 +1,503 @@
-import React, { useState } from 'react';
-import { LogoIcon } from './Icons';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  LogoIcon,
+  UserCircleIcon,
+  EnvelopeIcon,
+  LockClosedIcon,
+  MiniSpinnerIcon,
+} from './Icons';
+
+type AuthMode = 'login' | 'signup' | 'forgot';
 
 interface LoginPromptViewProps {
-  onLogin: () => Promise<void>;
   theme: 'light' | 'dark';
+  onLogin?: () => Promise<void>;
+  onEmailLogin: (identifier: string, password: string) => Promise<void>;
+  onSignup: (input: { name: string; email: string; password: string }) => Promise<void>;
+  onPasswordReset: (identifier: string) => Promise<void>;
 }
 
-const MISSING_CLIENT_ID_MESSAGE =
-  'Google Sign-In requires configuration. Set VITE_GOOGLE_CLIENT_ID in your .env.local file to your OAuth web client ID.';
+type ActiveRequest = AuthMode | 'google' | null;
 
-export const LoginPromptView: React.FC<LoginPromptViewProps> = ({ onLogin, theme }) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const isGoogleConfigured = Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID);
-  const handleLogin = async () => {
-    setError(null);
-    if (!isGoogleConfigured) {
-      setError(MISSING_CLIENT_ID_MESSAGE);
-      return;
-    }
-    setIsLoading(true);
-    try {
-      await onLogin();
-    } catch (err) {
-      console.error('Google sign-in failed', err);
-      const message =
-        err instanceof Error
-          ? err.message
-          : 'Google Sign-In failed. Please check your internet connection and try again.';
-      setError(message);
-    } finally {
-      setIsLoading(false);
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+const getFeedbackClasses = (mode: AuthMode, type: 'success' | 'error') => {
+  const palette = {
+    login: {
+      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
+      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+    },
+    signup: {
+      success: 'bg-emerald-50 text-emerald-600 border-emerald-200',
+      error: 'bg-rose-50 text-rose-600 border-rose-200',
+    },
+    forgot: {
+      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
+      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+    },
+  } as const;
+
+  return palette[mode][type];
+};
+
+export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
+  theme,
+  onLogin,
+  onEmailLogin,
+  onSignup,
+  onPasswordReset,
+}) => {
+  const [mode, setMode] = useState<AuthMode>('login');
+  const [activeRequest, setActiveRequest] = useState<ActiveRequest>(null);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const [loginForm, setLoginForm] = useState({ identifier: '', password: '' });
+  const [signupForm, setSignupForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    acceptsTerms: false,
+  });
+  const [forgotForm, setForgotForm] = useState({ email: '' });
+
+  const isGoogleConfigured = useMemo(() => Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID), []);
+  const canUseGoogle = Boolean(onLogin) && isGoogleConfigured;
+
+  useEffect(() => {
+    setFeedback(null);
+  }, [mode]);
+
+  const setRequest = (request: ActiveRequest) => {
+    setActiveRequest(request);
+    if (request) {
+      setFeedback(null);
     }
   };
 
-  return (
-    <div className="bg-surface p-8 rounded-xl text-center flex flex-col items-center shadow-card max-w-lg mx-auto mt-4 md:mt-10">
-        <LogoIcon className="w-20 h-20 mb-4" theme={theme} />
-        <h2 className="text-2xl font-bold text-text-strong mb-2">Create a Profile to Continue</h2>
-        <p className="text-text-subtle mb-6">
-            Sign in with your Google account to track your attended matches, earn badges, view your personal stats, and connect
-            with the community.
-        </p>
-        <button
-            onClick={handleLogin}
-            disabled={isLoading || !isGoogleConfigured}
+  const resetRequest = () => setActiveRequest(null);
 
-            className="bg-primary text-white font-bold py-3 px-8 rounded-lg text-lg hover:bg-primary/90 transition-transform hover:scale-105 shadow-md focus:outline-none focus:ring-4 focus:ring-primary/50 disabled:opacity-70 disabled:cursor-not-allowed"
-        >
-            {isLoading ? 'Connecting...' : 'Continue with Google'}
-        </button>
+  const handleCredentialLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
 
-        {!isGoogleConfigured ? (
-            <p className="mt-4 text-sm text-amber-600" role="alert">
-                {MISSING_CLIENT_ID_MESSAGE}
+    setRequest('login');
+    try {
+      await onEmailLogin(loginForm.identifier, loginForm.password);
+      setFeedback({ type: 'success', message: 'Welcome back! Loading your profile…' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'Unable to sign in with those details. Please try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleSignup = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
+
+    if (!signupForm.acceptsTerms) {
+      setFeedback({ type: 'error', message: 'Please agree to the Terms & Privacy to continue.' });
+      return;
+    }
+
+    if (!signupForm.name.trim()) {
+      setFeedback({ type: 'error', message: 'Enter your full name so we know what to call you.' });
+      return;
+    }
+
+    if (!signupForm.email.trim()) {
+      setFeedback({ type: 'error', message: 'Enter an email address to create your account.' });
+      return;
+    }
+
+    if (signupForm.password.length < 6) {
+      setFeedback({ type: 'error', message: 'Passwords need to be at least 6 characters long.' });
+      return;
+    }
+
+    if (signupForm.password !== signupForm.confirmPassword) {
+      setFeedback({ type: 'error', message: 'Passwords do not match. Please re-type them.' });
+      return;
+    }
+
+    setRequest('signup');
+    try {
+      await onSignup({
+        name: signupForm.name,
+        email: signupForm.email,
+        password: signupForm.password,
+      });
+      setFeedback({ type: 'success', message: 'Account created! Setting up your experience…' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'We could not create your account just yet. Try again shortly.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleForgotPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
+
+    if (!forgotForm.email.trim()) {
+      setFeedback({ type: 'error', message: 'Enter the email linked to your account.' });
+      return;
+    }
+
+    setRequest('forgot');
+    try {
+      await onPasswordReset(forgotForm.email);
+      setFeedback({
+        type: 'success',
+        message: 'Check your inbox for reset instructions (they may be in spam).',
+      });
+      setForgotForm({ email: '' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'We could not find that email. Double check and try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    if (!canUseGoogle || activeRequest) return;
+
+    setRequest('google');
+    try {
+      await onLogin?.();
+      setFeedback({ type: 'success', message: 'Connecting you with Google…' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'Google sign-in failed. Please try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const renderFeedback = () => {
+    if (!feedback) {
+      return null;
+    }
+    return (
+      <div
+        className={`mt-5 rounded-full border px-5 py-2 text-sm font-medium tracking-wide ${getFeedbackClasses(
+          mode,
+          feedback.type
+        )}`}
+      >
+        {feedback.message}
+      </div>
+    );
+  };
+
+  const busy = (request: ActiveRequest) => activeRequest === request;
+
+  const renderLoginCard = () => (
+    <div className="relative mx-auto w-full max-w-[420px]">
+      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-b from-[#08304a] via-[#062436] to-[#03131f] px-8 pb-12 pt-32 text-white shadow-2xl">
+        <div className="absolute inset-x-0 -top-24 flex justify-center">
+          <div className="flex h-44 w-44 items-center justify-center rounded-full border border-white/10 bg-gradient-to-b from-[#0f4460] to-[#03111b] shadow-[0px_25px_60px_rgba(0,0,0,0.45)]">
+            <LogoIcon className="h-24 w-24 drop-shadow-lg" theme={theme} />
+          </div>
+        </div>
+
+        <div className="text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
+        </div>
+
+        <form className="mt-10 space-y-5" onSubmit={handleCredentialLogin}>
+          <div>
+            <label className="sr-only" htmlFor="auth-identifier">
+              Email or phone number
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-base transition focus-within:border-white focus-within:bg-white/10">
+              <EnvelopeIcon className="h-5 w-5 text-white/70" />
+              <input
+                id="auth-identifier"
+                type="text"
+                autoComplete="username"
+                placeholder="Email or Phone"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={loginForm.identifier}
+                onChange={(event) => setLoginForm((prev) => ({ ...prev, identifier: event.target.value }))}
+                disabled={busy('login')}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="sr-only" htmlFor="auth-password">
+              Password
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-base transition focus-within:border-white focus-within:bg-white/10">
+              <LockClosedIcon className="h-5 w-5 text-white/70" />
+              <input
+                id="auth-password"
+                type="password"
+                autoComplete="current-password"
+                placeholder="Password"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={loginForm.password}
+                onChange={(event) => setLoginForm((prev) => ({ ...prev, password: event.target.value }))}
+                disabled={busy('login')}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between text-sm font-medium text-white/70">
+            <button
+              type="button"
+              className="underline decoration-white/40 decoration-dotted underline-offset-4 hover:text-white"
+              onClick={() => setMode('forgot')}
+            >
+              Forgot Password?
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#032130] shadow-[0px_10px_30px_rgba(3,23,34,0.4)] transition hover:bg-white/90 disabled:opacity-70"
+            disabled={busy('login')}
+          >
+            {busy('login') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#032130]" />
+                Logging in…
+              </>
+            ) : (
+              'Login'
+            )}
+          </button>
+
+          <div className="flex items-center gap-4 text-white/40">
+            <span className="h-px flex-1 bg-white/20" />
+            <span className="text-xs uppercase tracking-[0.5em]">or</span>
+            <span className="h-px flex-1 bg-white/20" />
+          </div>
+
+          <button
+            type="button"
+            className="w-full rounded-full border border-white/20 bg-transparent py-3 text-base font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+            onClick={() => setMode('signup')}
+          >
+            Create an account
+          </button>
+
+          {canUseGoogle ? (
+            <button
+              type="button"
+              className="w-full rounded-full border border-white/20 bg-transparent py-3 text-base font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+              onClick={handleGoogleLogin}
+              disabled={busy('google')}
+            >
+              {busy('google') ? 'Connecting to Google…' : 'Continue with Google'}
+            </button>
+          ) : null}
+
+          {!canUseGoogle && onLogin && !isGoogleConfigured ? (
+            <p className="text-center text-xs text-white/50">
+              Google Sign-In isn&apos;t configured. Set <code className="rounded bg-black/30 px-1">VITE_GOOGLE_CLIENT_ID</code> to enable it.
             </p>
-        ) : null}
-        {error ? <p className="mt-4 text-sm text-red-500" role="alert">{error}</p> : null}
+          ) : null}
+
+          {renderFeedback()}
+        </form>
+      </div>
+    </div>
+  );
+
+  const renderSignupCard = () => (
+    <div className="mx-auto w-full max-w-[480px] overflow-hidden rounded-[36px] bg-white shadow-2xl">
+      <div className="bg-[#031d2c] px-10 pb-12 pt-16 text-white">
+        <p className="text-lg font-semibold uppercase tracking-[0.35em] text-white/60">Let&apos;s</p>
+        <h2 className="mt-3 text-4xl font-heading leading-[1.15]">
+          Create
+          <br />
+          Your Account
+        </h2>
+        <p className="mt-4 max-w-sm text-sm text-white/70">
+          Join the community, track your matchdays, and unlock exclusive rugby league stats.
+        </p>
+      </div>
+
+      <form className="bg-white px-10 py-10" onSubmit={handleSignup}>
+        <div className="space-y-5">
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <UserCircleIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="text"
+              placeholder="Full Name"
+              autoComplete="name"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.name}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, name: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <EnvelopeIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="email"
+              placeholder="Email Address"
+              autoComplete="email"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.email}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, email: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="password"
+              placeholder="Password"
+              autoComplete="new-password"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.password}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, password: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="password"
+              placeholder="Retype Password"
+              autoComplete="new-password"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.confirmPassword}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, confirmPassword: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <label className="flex items-center gap-3 text-sm text-[#0B2A2F]/70">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border border-[#0B2A2F]/30 text-[#0B2A2F] focus:ring-[#0B2A2F]"
+              checked={signupForm.acceptsTerms}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, acceptsTerms: event.target.checked }))}
+              disabled={busy('signup')}
+            />
+            <span>
+              I agree to the <span className="font-semibold text-[#0B2A2F]">Terms &amp; Privacy</span>
+            </span>
+          </label>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-[#d9e4ec] py-3 text-base font-semibold text-[#0B2A2F] transition hover:bg-[#c8d7e2] disabled:opacity-60"
+            disabled={busy('signup')}
+          >
+            {busy('signup') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#0B2A2F]" />
+                Signing you up…
+              </>
+            ) : (
+              'Sign Up'
+            )}
+          </button>
+
+          {renderFeedback()}
+
+          <p className="mt-6 text-center text-sm text-[#0B2A2F]/70">
+            Have an account?
+            <button
+              type="button"
+              className="ml-1 font-semibold text-[#0B2A2F] underline decoration-dotted underline-offset-4"
+              onClick={() => setMode('login')}
+            >
+              Sign In
+            </button>
+          </p>
+        </div>
+      </form>
+    </div>
+  );
+
+  const renderForgotCard = () => (
+    <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-[36px] bg-white text-[#0B2A2F] shadow-2xl">
+      <div className="px-10 pb-8 pt-12 text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[#0B2A2F]/10 text-[#0B2A2F]">
+          <LockClosedIcon className="h-7 w-7" />
+        </div>
+        <h2 className="text-3xl font-heading font-semibold text-[#133347]">Forgot Password?</h2>
+        <p className="mt-3 text-sm text-[#375566]">No worries, we&apos;ll send you reset instructions.</p>
+      </div>
+
+      <div className="bg-[#031d2c] px-10 pb-10 pt-10 text-white">
+        <form className="space-y-6" onSubmit={handleForgotPassword}>
+          <div>
+            <label className="sr-only" htmlFor="forgot-email">
+              Email address
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-5 py-3 transition focus-within:border-white focus-within:bg-white/20">
+              <EnvelopeIcon className="h-5 w-5 text-white/80" />
+              <input
+                id="forgot-email"
+                type="email"
+                placeholder="Enter your Email"
+                autoComplete="email"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={forgotForm.email}
+                onChange={(event) => setForgotForm({ email: event.target.value })}
+                disabled={busy('forgot')}
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#031d2c] shadow-[0px_10px_40px_rgba(0,0,0,0.35)] transition hover:bg-white/95 disabled:opacity-70"
+            disabled={busy('forgot')}
+          >
+            {busy('forgot') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#031d2c]" />
+                Sending reset link…
+              </>
+            ) : (
+              'Reset Password'
+            )}
+          </button>
+
+          {renderFeedback()}
+
+          <button
+            type="button"
+            className="mx-auto block text-sm font-semibold text-white/80 underline decoration-dotted underline-offset-4 hover:text-white"
+            onClick={() => setMode('login')}
+          >
+            Back to Login
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="py-10">
+      {mode === 'login' ? renderLoginCard() : null}
+      {mode === 'signup' ? renderSignupCard() : null}
+      {mode === 'forgot' ? renderForgotCard() : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the Google-only login prompt with a three-screen experience for login, sign-up, and password reset
- extend the auth context to support credential storage, email login, account creation, and password reset requests that persist to local storage
- add a reusable mail icon and wire the new auth flow into the main app gating logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df6b54d578832c9b744fd0f200b830