### PR TITLE
Refine login prompt layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,8 @@ import { LoginPromptView } from './components/LoginPromptView';
 import { LogoIcon, MenuIcon } from './components/Icons';
 import { syncThemeWithFavouriteTeam } from './utils/themeUtils';
 
+const protectedViews: View[] = ['MY_MATCHES', 'STATS', 'BADGES', 'PROFILE', 'COMMUNITY', 'ADMIN'];
+
 const App: React.FC = () => {
   const [view, setView] = useState<View>('PROFILE');
   const [theme, toggleTheme] = useTheme();
@@ -66,8 +68,8 @@ const App: React.FC = () => {
 
   useEffect(() => {
     if (!initialLoadStarted.current) {
-        initialLoadStarted.current = true;
-        loadAppData();
+      initialLoadStarted.current = true;
+      loadAppData();
     }
   }, [loadAppData]);
 
@@ -91,6 +93,14 @@ const App: React.FC = () => {
     }
   };
 
+  const shouldShowLoginPrompt = !currentUser && protectedViews.includes(view);
+
+  useEffect(() => {
+    if (shouldShowLoginPrompt) {
+      setIsMobileNavOpen(false);
+    }
+  }, [shouldShowLoginPrompt]);
+
   const renderContent = () => {
     if (error) {
       return <ErrorDisplay message={error} onRetry={loadAppData} />;
@@ -102,8 +112,7 @@ const App: React.FC = () => {
       </div>;
     }
 
-    const protectedViews: View[] = ['MY_MATCHES', 'STATS', 'BADGES', 'PROFILE', 'COMMUNITY', 'ADMIN'];
-    if (!currentUser && protectedViews.includes(view)) {
+    if (shouldShowLoginPrompt) {
       return (
         <LoginPromptView
           onLogin={login}
@@ -189,43 +198,56 @@ const App: React.FC = () => {
     }
   };
 
+  const mainBaseClasses = 'mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8';
+  const mainSpacing = shouldShowLoginPrompt ? 'py-16 md:py-20 flex items-center justify-center' : 'py-10 md:py-12 pb-16';
+
   return (
     <div className="min-h-screen font-sans text-text app-background">
-      <Header
-        setView={setView}
-        theme={theme}
-        isMobileNavOpen={isMobileNavOpen}
-        onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
-      />
-      <button
-        type="button"
-        className="hidden md:flex fixed top-6 right-6 z-20 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
-        onClick={() => setIsMobileNavOpen(true)}
-        aria-label="Open navigation menu"
-      >
-        <MenuIcon className="w-5 h-5" />
-        <span>Menu</span>
-      </button>
-      <main className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8 py-10 md:py-12 pb-16">
-        <div className="space-y-8">
-          {renderContent()}
-        </div>
+      {!shouldShowLoginPrompt ? (
+        <>
+          <Header
+            setView={setView}
+            theme={theme}
+            isMobileNavOpen={isMobileNavOpen}
+            onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
+          />
+          <button
+            type="button"
+            className="hidden md:flex fixed top-6 right-6 z-20 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
+            onClick={() => setIsMobileNavOpen(true)}
+            aria-label="Open navigation menu"
+          >
+            <MenuIcon className="w-5 h-5" />
+            <span>Menu</span>
+          </button>
+        </>
+      ) : null}
+      <main className={`${mainBaseClasses} ${mainSpacing}`}>
+        {shouldShowLoginPrompt ? (
+          <div className="w-full">{renderContent()}</div>
+        ) : (
+          <div className="space-y-8">{renderContent()}</div>
+        )}
       </main>
-      <MobileNav
-        currentView={view}
-        setView={setView}
-        currentUser={currentUser}
-        isOpen={isMobileNavOpen}
-        onClose={() => setIsMobileNavOpen(false)}
-        theme={themeMode}
-        toggleTheme={toggleTheme}
-        onLogout={logout}
-      />
-      <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface/70 backdrop-blur">
-        <LogoIcon className="w-12 h-12 mx-auto mb-3" theme={themeMode} />
-        <p className="font-semibold text-text">The Scrum Book</p>
-        <p className="mt-1">Your ultimate rugby league companion. Track matches, earn badges, and connect with other fans.</p>
-      </footer>
+      {!shouldShowLoginPrompt ? (
+        <>
+          <MobileNav
+            currentView={view}
+            setView={setView}
+            currentUser={currentUser}
+            isOpen={isMobileNavOpen}
+            onClose={() => setIsMobileNavOpen(false)}
+            theme={themeMode}
+            toggleTheme={toggleTheme}
+            onLogout={logout}
+          />
+          <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface/70 backdrop-blur">
+            <LogoIcon className="w-12 h-12 mx-auto mb-3" theme={themeMode} />
+            <p className="font-semibold text-text">The Scrum Book</p>
+            <p className="mt-1">Your ultimate rugby league companion. Track matches, earn badges, and connect with other fans.</p>
+          </footer>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -206,20 +206,20 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
   const busy = (request: ActiveRequest) => activeRequest === request;
 
   const renderLoginCard = () => (
-    <div className="relative mx-auto w-full max-w-[420px]">
-      <div className="relative overflow-hidden rounded-[36px] bg-gradient-to-b from-[#08304a] via-[#062436] to-[#03131f] px-8 pb-12 pt-32 text-white shadow-2xl">
-        <div className="absolute inset-x-0 -top-24 flex justify-center">
-          <div className="flex h-44 w-44 items-center justify-center rounded-full border border-white/10 bg-gradient-to-b from-[#0f4460] to-[#03111b] shadow-[0px_25px_60px_rgba(0,0,0,0.45)]">
-            <LogoIcon className="h-24 w-24 drop-shadow-lg" theme={theme} />
+    <div className="mx-auto w-full max-w-[420px]">
+      <div className="overflow-hidden rounded-[36px] bg-gradient-to-b from-[#08304a] via-[#062436] to-[#03131f] px-8 pb-12 pt-14 text-white shadow-2xl">
+        <div className="flex flex-col items-center text-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/10 bg-white/10 shadow-[0px_15px_35px_rgba(3,19,31,0.45)]">
+            <LogoIcon className="h-12 w-12 drop-shadow" theme={theme} />
           </div>
-        </div>
-
-        <div className="text-center">
-          <p className="text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
           <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
+          <p className="mt-3 max-w-xs text-sm text-white/60">
+            Sign in to manage your matchdays, track your stats, and stay connected with the rugby league community.
+          </p>
         </div>
 
-        <form className="mt-10 space-y-5" onSubmit={handleCredentialLogin}>
+        <form className="mt-8 space-y-5" onSubmit={handleCredentialLogin}>
           <div>
             <label className="sr-only" htmlFor="auth-identifier">
               Email or phone number
@@ -494,7 +494,7 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
   );
 
   return (
-    <div className="py-10">
+    <div className="py-6 sm:py-10">
       {mode === 'login' ? renderLoginCard() : null}
       {mode === 'signup' ? renderSignupCard() : null}
       {mode === 'forgot' ? renderForgotCard() : null}


### PR DESCRIPTION
## Summary
- hide the header, desktop menu button, mobile nav, and footer when the login prompt is shown so the screen focuses on authentication
- refresh the login prompt card with a centered logo treatment and supporting copy to avoid the clipped floating badge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df74335a0c832cb4f801aa6166449f