### PR TITLE
Ensure logo imagery retains its original proportions

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -17,7 +17,7 @@ export const RugbyBallIcon: React.FC<IconProps> = (props) => (
     </svg>
 );
 
-export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', alt, ...props }) => {
+export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', alt, style, ...props }) => {
   const resolvedSrc = theme === 'dark' ? logoDarkSrc : logoSrc;
 
   return (
@@ -26,6 +26,11 @@ export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', 
       alt={alt ?? 'The Scrum Book logo'}
       className={className}
       loading="lazy"
+      style={{
+        objectFit: 'contain',
+        objectPosition: 'center',
+        ...style,
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- update the shared LogoIcon component to use object-fit containment so scaling never distorts the image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df8e1449d4832cba229934f536338a