### PR TITLE
Improve mobile bottom navigation layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -255,7 +255,7 @@ const App: React.FC = () => {
           />
           <button
             type="button"
-            className="hidden md:flex fixed top-6 right-6 z-20 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
+            className="hidden md:flex fixed top-6 right-6 z-40 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
             onClick={() => setIsMobileNavOpen(true)}
             aria-label="Open navigation menu"
           >

--- a/components/MobileBottomBar.tsx
+++ b/components/MobileBottomBar.tsx
@@ -19,34 +19,38 @@ export const MobileBottomBar: React.FC<MobileBottomBarProps> = ({ currentView, s
 
   return (
     <nav className="md:hidden fixed inset-x-0 bottom-0 z-20 border-t border-border/70 bg-surface/95 backdrop-blur">
-      <div className="flex items-center gap-2 overflow-x-auto px-3 py-2">
-        <button
-          type="button"
-          onClick={handleBack}
-          className="flex shrink-0 items-center gap-1 rounded-full border border-border/70 bg-surface-alt/70 px-3 py-1.5 text-xs font-semibold text-text-subtle transition-colors hover:border-border hover:text-text"
-          aria-label="Go back"
-        >
-          <ArrowLeftIcon className="h-4 w-4" />
-          <span>Back</span>
-        </button>
-        {mainNavigationItems.map(({ label, view }) => {
-          const isActive = currentView === view;
-          return (
-            <button
-              key={view}
-              type="button"
-              onClick={() => setView(view)}
-              className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-semibold transition-colors ${
-                isActive
-                  ? 'bg-primary/15 text-primary border border-primary/40 shadow-sm'
-                  : 'text-text-subtle hover:text-text hover:bg-surface-alt/80 border border-transparent'
-              }`}
-              aria-current={isActive ? 'page' : undefined}
-            >
-              {label}
-            </button>
-          );
-        })}
+      <div className="mx-auto w-full max-w-2xl px-3 pt-2 pb-[calc(env(safe-area-inset-bottom)+10px)]">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="w-full rounded-full border border-border/70 bg-surface-alt/70 px-3 py-2 text-[11px] font-semibold leading-tight text-text-subtle transition-colors hover:border-border hover:text-text"
+            aria-label="Go back"
+          >
+            <span className="flex items-center justify-center gap-1">
+              <ArrowLeftIcon className="h-3.5 w-3.5" />
+              <span>Back</span>
+            </span>
+          </button>
+          {mainNavigationItems.map(({ label, view }) => {
+            const isActive = currentView === view;
+            return (
+              <button
+                key={view}
+                type="button"
+                onClick={() => setView(view)}
+                className={`w-full rounded-full px-3 py-2 text-[11px] font-semibold leading-tight transition-colors ${
+                  isActive
+                    ? 'bg-primary/15 text-primary border border-primary/40 shadow-sm'
+                    : 'text-text-subtle hover:text-text hover:bg-surface-alt/80 border border-transparent'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <span className="block whitespace-normal break-words text-center">{label}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- arrange the mobile bottom navigation buttons in a responsive grid so they fit within the viewport and add safe-area padding
- ensure the desktop burger menu button appears above the fixed top bar by raising its z-index

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfa61c8f44832c8a882e3747028f57