### PR TITLE
Default to dark theme and remove appearance toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,7 +61,7 @@ const App: React.FC = () => {
 
     return 'PROFILE';
   });
-  const [theme, toggleTheme] = useTheme();
+  const [theme] = useTheme();
   const themeMode = theme === 'dark' ? 'dark' : 'light';
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
@@ -280,7 +280,6 @@ const App: React.FC = () => {
             isOpen={isMobileNavOpen}
             onClose={() => setIsMobileNavOpen(false)}
             theme={themeMode}
-            toggleTheme={toggleTheme}
             onLogout={logout}
           />
           <MobileBottomBar currentView={view} setView={setView} />

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -14,8 +14,6 @@ import {
   ChartBarIcon,
   LogoIcon,
   XMarkIcon,
-  SunIcon,
-  MoonIcon,
   ArrowLeftOnRectangleIcon,
 } from './Icons';
 
@@ -26,7 +24,6 @@ interface MobileNavProps {
   isOpen: boolean;
   onClose: () => void;
   theme: 'light' | 'dark';
-  toggleTheme: () => void;
   onLogout: () => void;
 }
 
@@ -62,7 +59,6 @@ export const MobileNav: React.FC<MobileNavProps> = ({
   isOpen,
   onClose,
   theme,
-  toggleTheme,
   onLogout,
 }) => {
   const handleNavigate = (view: View) => {
@@ -188,32 +184,6 @@ export const MobileNav: React.FC<MobileNavProps> = ({
                   );
                 })}
               </ul>
-            </div>
-
-            <div className="rounded-xl border border-border/70 bg-surface-alt/40 px-4 py-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-heading text-lg text-text-strong">Appearance</p>
-                  <p className="text-xs text-text-subtle">Switch between light and dark themes</p>
-                </div>
-                <button
-                  onClick={toggleTheme}
-                  className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface px-3 py-2 text-sm font-semibold text-text-subtle transition-colors hover:text-text hover:border-border"
-                  aria-label="Toggle theme"
-                >
-                  {theme === 'dark' ? (
-                    <>
-                      <SunIcon className="h-4 w-4" />
-                      <span>Light</span>
-                    </>
-                  ) : (
-                    <>
-                      <MoonIcon className="h-4 w-4" />
-                      <span>Dark</span>
-                    </>
-                  )}
-                </button>
-              </div>
             </div>
 
             <div className="rounded-xl border border-border/60 bg-surface-alt/60 px-4 py-4 text-sm text-text-subtle">

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -2,8 +2,8 @@ import { useEffect } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 
 export const useTheme = (): [string, () => void] => {
-  // Default to light, but user's preference in localStorage will override it.
-  const [theme, setTheme] = useLocalStorage<string>('theme', 'light');
+  // Default to dark, but the user's preference in localStorage will override it.
+  const [theme, setTheme] = useLocalStorage<string>('theme', 'dark');
 
   useEffect(() => {
     const root = window.document.documentElement;


### PR DESCRIPTION
## Summary
- remove the mobile navigation appearance card and theme toggle controls
- default the app theme to dark mode by default while still respecting stored preferences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfae52209c832cb99d48f57f04fc2f