### PR TITLE
Open match add-to-calendar links in Google Calendar

### DIFF
--- a/components/MatchListItem.tsx
+++ b/components/MatchListItem.tsx
@@ -32,7 +32,7 @@ const isToday = (dateString: string): boolean => {
   );
 };
 
-const formatICalDate = (date: Date) => date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+const formatCalendarDate = (date: Date) => date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
 
 export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended, onAttend, distance }) => {
   const [checkinState, setCheckinState] = useState<{
@@ -63,33 +63,22 @@ export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended,
 
     const startDate = new Date(match.startTime);
     const endDate = new Date(startDate.getTime() + 105 * 60 * 1000);
+    const summary = `${match.homeTeam.name} vs ${match.awayTeam.name}`;
+    const details = `Betfred Super League: ${summary}`;
 
-    const icsContent = [
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'BEGIN:VEVENT',
-      `UID:${match.id}@thescrumbook.com`,
-      `DTSTAMP:${formatICalDate(new Date())}`,
-      `DTSTART:${formatICalDate(startDate)}`,
-      `DTEND:${formatICalDate(endDate)}`,
-      `SUMMARY:${match.homeTeam.name} vs ${match.awayTeam.name}`,
-      `DESCRIPTION:Betfred Super League: ${match.homeTeam.name} vs ${match.awayTeam.name}`,
-      `LOCATION:${match.venue}`,
-      'END:VEVENT',
-      'END:VCALENDAR',
-    ].join('\r\n');
+    const calendarUrl = new URL('https://calendar.google.com/calendar/render');
+    calendarUrl.searchParams.set('action', 'TEMPLATE');
+    calendarUrl.searchParams.set('text', summary);
+    calendarUrl.searchParams.set('dates', `${formatCalendarDate(startDate)}/${formatCalendarDate(endDate)}`);
+    calendarUrl.searchParams.set('details', details);
+    calendarUrl.searchParams.set('location', match.venue);
+    calendarUrl.searchParams.set('sf', 'true');
+    calendarUrl.searchParams.set('output', 'xml');
 
-    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement('a');
-    link.href = url;
-    const fileName = `${match.homeTeam.name.replace(/\s/g, '_')}-vs-${match.awayTeam.name.replace(/\s/g, '_')}.ics`;
-    link.setAttribute('download', fileName);
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    const newWindow = window.open(calendarUrl.toString(), '_blank');
+    if (!newWindow) {
+      window.location.href = calendarUrl.toString();
+    }
   };
 
   const handleCheckIn = (event: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- replace the ICS file download with a deep link that opens Google Calendar's event creator
- pre-populate event name, timing, details, and venue so fans can save fixtures quickly
- fall back to in-tab navigation if the pop-up window is blocked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb78cdda4832c97804d0338f66a06