### PR TITLE
Ensure dates use UK formatting

### DIFF
--- a/components/MatchListItem.tsx
+++ b/components/MatchListItem.tsx
@@ -11,6 +11,7 @@ import {
 import { TeamLogo } from './TeamLogo';
 import { ALL_VENUES } from '../services/mockData';
 import { getDistance } from '../utils/geolocation';
+import { formatDateUK } from '../utils/date';
 
 interface MatchListItemProps {
   match: Match;
@@ -219,7 +220,7 @@ export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended,
           </div>
           <div className="flex items-center gap-1.5">
             <ClockIcon className="h-4 w-4" />
-            <span>{new Date(match.startTime).toLocaleDateString()}</span>
+            <span>{formatDateUK(match.startTime)}</span>
           </div>
           {distance !== undefined && (
             <div className="font-semibold text-primary">

--- a/components/MatchdayView.tsx
+++ b/components/MatchdayView.tsx
@@ -1,22 +1,13 @@
 import React, { useMemo, useState } from 'react';
 import type { Match } from '../types';
 import { MatchListItem } from './MatchListItem';
+import { formatDateUK } from '../utils/date';
 
 interface MatchdayViewProps {
   matches: Match[];
   attendedMatchIds: string[];
   onAttend: (match: Match) => void;
 }
-
-const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString(undefined, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-};
 
 type ActiveTab = 'fixtures' | 'results';
 
@@ -89,7 +80,7 @@ export const MatchdayView: React.FC<MatchdayViewProps> = ({ matches, attendedMat
         {sortedDateKeys.map(dateKey => (
           <div key={dateKey}>
             <h2 className="mb-4 border-b-2 border-primary pb-2 text-xl font-bold text-text-strong">
-              {formatDate(dateKey)}
+              {formatDateUK(dateKey)}
             </h2>
             <div className="space-y-4">
               {groupedMatches[dateKey].map(match => (

--- a/components/MyMatchesView.tsx
+++ b/components/MyMatchesView.tsx
@@ -5,6 +5,7 @@ import { TeamLogo } from './TeamLogo';
 import { useAuth } from '../contexts/AuthContext';
 import { PhotoUploadModal } from './PhotoUploadModal';
 import { PhotoViewerModal } from './PhotoViewerModal';
+import { formatDateUK } from '../utils/date';
 
 interface MyMatchesViewProps {
     attendedMatches: AttendedMatch[];
@@ -162,7 +163,7 @@ export const MyMatchesView: React.FC<MyMatchesViewProps> = ({ attendedMatches, o
                                     <div className="flex justify-between items-start mb-3">
                                         <p className="text-sm text-primary font-semibold">{match.competition?.name || 'Super League'}</p>
                                         <p className="text-xs text-text-subtle">
-                                            Attended: {new Date(attendedOn).toLocaleDateString()}
+                                            Attended: {formatDateUK(attendedOn)}
                                         </p>
                                     </div>
 
@@ -195,7 +196,7 @@ export const MyMatchesView: React.FC<MyMatchesViewProps> = ({ attendedMatches, o
                                         </div>
                                         <div className="flex items-center gap-2">
                                             <CalendarIcon className="w-3 h-3"/>
-                                            <span>Match Date: {new Date(match.startTime).toLocaleDateString()}</span>
+                                            <span>Match Date: {formatDateUK(match.startTime)}</span>
                                         </div>
                                     </div>
                                 </div>

--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { AttendedMatch } from '../types';
 import { XMarkIcon } from './Icons';
 import { TeamLogo } from './TeamLogo';
+import { formatDateUK } from '../utils/date';
 
 interface PhotoViewerModalProps {
   isOpen: boolean;
@@ -51,7 +52,7 @@ export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onCl
             </div>
           </div>
           <p className="text-xs text-text-subtle text-center mt-2">
-            {match.venue} &bull; Attended on {new Date(attendedOn).toLocaleDateString()}
+            {match.venue} &bull; Attended on {formatDateUK(attendedOn)}
           </p>
         </div>
       </div>

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -16,6 +16,7 @@ import {
 } from './Icons';
 import { TEAMS } from '../services/mockData';
 import styles from './ProfileView.module.css';
+import { formatDateUK } from '../utils/date';
 
 // Helper to get team details by ID
 const getTeamById = (teamId?: string) => {
@@ -206,7 +207,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                     <span className={styles.matchMeta}>
                       {recentMatch.match.venue}
                       {' · '}
-                      {new Date(recentMatch.attendedOn).toLocaleDateString()}
+                      {formatDateUK(recentMatch.attendedOn)}
                     </span>
                   </div>
                 ) : (

--- a/components/StatsView.tsx
+++ b/components/StatsView.tsx
@@ -4,6 +4,7 @@ import type { AttendedMatch, User } from '../types';
 import { TEAMS } from '../services/mockData';
 import { TeamLogo } from './TeamLogo';
 import { ShareIcon, ShieldCheckIcon, UserCircleIcon } from './Icons';
+import { formatDateUK } from '../utils/date';
 
 interface StatsViewProps {
     attendedMatches: AttendedMatch[];
@@ -135,7 +136,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
                         <h3 className="absolute top-2 left-4 text-white font-bold text-sm">BEST MATCH OF 2024</h3>
                     </div>
                     <div className="p-4">
-                        <p className="text-xs font-semibold text-text-subtle">{new Date(stats.bestMatchOfSeason.match.startTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric'})}</p>
+                        <p className="text-xs font-semibold text-text-subtle">{formatDateUK(stats.bestMatchOfSeason.match.startTime)}</p>
                         <p className="font-bold">{stats.bestMatchOfSeason.match.venue}</p>
                         <div className="flex items-center justify-between mt-2">
                              <div className="flex items-center gap-2">

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,13 @@
+export const formatDateUK = (dateInput: string | number | Date): string => {
+  const date = new Date(dateInput);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};


### PR DESCRIPTION
## Summary
- add a shared date formatting helper that renders dates in UK DD/MM/YYYY format
- update match- and profile-related components to use the new helper for all displayed dates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb7e83584832ca61559b3d19ca6c0