### PR TITLE
Refine profile page layout

### DIFF
--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -7,7 +7,9 @@
   --text-strong: var(--clr-text-strong);
   --text-subtle: var(--clr-text-subtle);
 
-  min-height: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   background: linear-gradient(180deg, rgba(7, 11, 23, 0.15) 0%, rgba(7, 11, 23, 0) 30%), #f5f7fb;
   color: var(--text-strong);
 }
@@ -36,6 +38,8 @@
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 5vw, 3rem);
+  width: min(1080px, 100%);
+  margin: 0 auto;
 }
 
 .identityRow {
@@ -262,6 +266,8 @@
   position: relative;
   margin-top: clamp(-5.5rem, -9vw, -6.5rem);
   padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 5vw, 3rem) 3.5rem;
+  width: min(1080px, 100%);
+  margin-inline: auto;
 }
 
 .summaryGrid {
@@ -298,10 +304,18 @@
 
 .cardHeader button {
   border: none;
-  background: transparent;
+  background: rgba(59, 130, 246, 0.1);
   color: var(--clr-primary);
   font-weight: 600;
   cursor: pointer;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.cardHeader button:hover {
+  background: rgba(59, 130, 246, 0.18);
+  transform: translateY(-1px);
 }
 
 .cardBody {
@@ -334,7 +348,7 @@
 .matchSummary {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
 .matchSummary p {
@@ -399,10 +413,36 @@
   box-shadow: 0 24px 40px -28px rgba(15, 23, 42, 0.75);
 }
 
-.quickActions svg {
-  width: 28px;
-  height: 28px;
+.quickActions button svg {
+  width: 24px;
+  height: 24px;
   color: var(--clr-primary);
+}
+
+.quickActions button span {
+  font-size: 0.95rem;
+}
+
+.emptyState {
+  margin: 0;
+  color: var(--text-subtle);
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .identityRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cardBody {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .logoWrap {
+    align-self: flex-end;
+  }
 }
 
 @media (max-width: 640px) {

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -56,6 +56,11 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
     return [...attendedMatches].sort((a, b) => new Date(b.attendedOn).getTime() - new Date(a.attendedOn).getTime())[0];
   }, [attendedMatches]);
 
+  const displayName = useMemo(() => {
+    const trimmed = (user.name ?? '').trim();
+    return trimmed.length > 0 ? trimmed : 'Rugby Fan';
+  }, [user.name]);
+
   const profileTagline = useMemo(() => {
     const matchCount = attendedMatches.length;
     if (matchCount >= 20) {
@@ -118,13 +123,14 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                         value={pendingName}
                         onChange={(e) => setPendingName(e.target.value)}
                         onBlur={handleSaveName}
+                        placeholder="Enter your name"
                         autoFocus
                       />
                       <button type="submit">Save</button>
                     </form>
                   ) : (
                     <button type="button" onClick={() => setIsEditingName(true)} className={styles.nameButton}>
-                      <span>{user.name}</span>
+                      <span>{displayName}</span>
                       <PencilIcon aria-hidden="true" />
                     </button>
                   )}
@@ -150,7 +156,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
               </div>
             </div>
 
-            <dl className={styles.statRow}>
+            <dl className={styles.statRow} aria-label="Profile highlights">
               <div className={styles.statCard}>
                 <ListBulletIcon aria-hidden="true" />
                 <dt>Matches Attended</dt>
@@ -190,7 +196,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                     <span>{favoriteTeam.name}</span>
                   </div>
                 ) : (
-                  <p>No favorite team selected yet.</p>
+                  <p className={styles.emptyState}>No favorite team selected yet.</p>
                 )}
               </div>
             </section>
@@ -210,9 +216,9 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
                       {formatDateUK(recentMatch.attendedOn)}
                     </span>
                   </div>
-                ) : (
-                  <p>No matches attended yet.</p>
-                )}
+                  ) : (
+                    <p className={styles.emptyState}>No matches attended yet.</p>
+                  )}
               </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add a fallback display name and hint text to improve the profile header editing experience
- surface friendlier empty states for team and match summaries and annotate the stat list for screen readers
- tighten the profile layout styling for better centering, button polish, and responsive quick actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd43b0b84832cbbd3cb181633229d