### PR TITLE
Broaden share tools in photo viewer

### DIFF
--- a/components/PhotoViewerModal.tsx
+++ b/components/PhotoViewerModal.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import type { AttendedMatch } from '../types';
-import { XMarkIcon } from './Icons';
+import { ShareIcon, XMarkIcon } from './Icons';
 import { TeamLogo } from './TeamLogo';
 
 interface PhotoViewerModalProps {
@@ -10,9 +10,163 @@ interface PhotoViewerModalProps {
 }
 
 export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onClose, attendedMatch }) => {
+  const [isShareMenuOpen, setIsShareMenuOpen] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+
   if (!isOpen || !attendedMatch || !attendedMatch.photoUrl) return null;
 
   const { match, attendedOn, photoUrl } = attendedMatch;
+
+  const shareDetails = useMemo(() => {
+    const formattedDate = new Date(attendedOn).toLocaleDateString();
+    const scoreLine = `${match.homeTeam.name} ${match.scores.home}-${match.scores.away} ${match.awayTeam.name}`;
+    const text = `Matchday memory: ${scoreLine} at ${match.venue} on ${formattedDate}.`;
+
+    return {
+      shareUrl: photoUrl,
+      shareText: text,
+      shareTitle: `${match.homeTeam.name} vs ${match.awayTeam.name} matchday memory`,
+      emailBody: `${text}\n\n${photoUrl}`,
+    };
+  }, [attendedOn, match, photoUrl]);
+
+  const attemptNativeShare = async () => {
+    if (typeof navigator === 'undefined' || !('share' in navigator)) {
+      return false;
+    }
+
+    try {
+      await (navigator as Navigator & { share: (data: ShareData) => Promise<void> }).share({
+        title: shareDetails.shareTitle,
+        text: shareDetails.shareText,
+        url: shareDetails.shareUrl,
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        // User dismissed the native share sheet; treat as handled.
+        return true;
+      }
+      return false;
+    }
+  };
+
+  const handleShareClick = async () => {
+    if (isShareMenuOpen) {
+      setIsShareMenuOpen(false);
+      return;
+    }
+
+    const wasShared = await attemptNativeShare();
+
+    if (!wasShared) {
+      setIsShareMenuOpen(true);
+    }
+  };
+
+  const handleOpenShareTarget = useCallback((url: string, { sameTab = false } = {}) => {
+    if (typeof window === 'undefined') return;
+    if (sameTab) {
+      window.location.href = url;
+    } else {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+    setIsShareMenuOpen(false);
+  }, [setIsShareMenuOpen]);
+
+  const handleDownloadPhoto = useCallback(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const normalizedName = shareDetails.shareTitle.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '').toLowerCase() || 'matchday-memory';
+    let extension = 'jpg';
+
+    try {
+      const url = new URL(shareDetails.shareUrl);
+      const pathSegment = url.pathname.split('.').pop();
+      if (pathSegment && /^[a-z0-9]{3,5}$/i.test(pathSegment)) {
+        extension = pathSegment.toLowerCase();
+      }
+    } catch {
+      const inlineMatch = shareDetails.shareUrl.match(/\.([a-z0-9]{3,5})(?:\?|$)/i);
+      if (inlineMatch) {
+        extension = inlineMatch[1].toLowerCase();
+      }
+    }
+
+    const link = document.createElement('a');
+    link.href = shareDetails.shareUrl;
+    link.download = `${normalizedName}.${extension}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setIsShareMenuOpen(false);
+  }, [shareDetails.shareTitle, shareDetails.shareUrl]);
+
+  const handleCopyLink = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      setCopyState('error');
+      setTimeout(() => setCopyState('idle'), 2000);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareDetails.shareUrl);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+
+    setTimeout(() => setCopyState('idle'), 2000);
+  };
+
+  const shareTargets = useMemo(() => {
+    const encodedMessage = encodeURIComponent(`${shareDetails.shareText} ${shareDetails.shareUrl}`);
+    const encodedUrl = encodeURIComponent(shareDetails.shareUrl);
+    const encodedQuote = encodeURIComponent(shareDetails.shareText);
+    const encodedEmailBody = encodeURIComponent(shareDetails.emailBody);
+    const encodedTitle = encodeURIComponent(shareDetails.shareTitle);
+
+    return [
+      {
+        label: 'WhatsApp',
+        action: () => handleOpenShareTarget(`https://wa.me/?text=${encodedMessage}`),
+      },
+      {
+        label: 'Instagram',
+        action: () => handleOpenShareTarget(`https://www.instagram.com/direct/new/?text=${encodedMessage}`),
+      },
+      {
+        label: 'Facebook',
+        action: () => handleOpenShareTarget(`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedQuote}`),
+      },
+      {
+        label: 'X (Twitter)',
+        action: () => handleOpenShareTarget(`https://twitter.com/intent/tweet?text=${encodedQuote}&url=${encodedUrl}`),
+      },
+      {
+        label: 'Telegram',
+        action: () => handleOpenShareTarget(`https://t.me/share/url?url=${encodedUrl}&text=${encodedQuote}`),
+      },
+      {
+        label: 'Messenger',
+        action: () => handleOpenShareTarget(`https://www.messenger.com/t/?link=${encodedUrl}&text=${encodedQuote}`),
+      },
+      {
+        label: 'Snapchat',
+        action: () => handleOpenShareTarget(`https://www.snapchat.com/scan?attachmentUrl=${encodedUrl}`),
+      },
+      {
+        label: 'Email',
+        action: () => handleOpenShareTarget(`mailto:?subject=${encodedTitle}&body=${encodedEmailBody}`, { sameTab: true }),
+      },
+      {
+        label: 'SMS',
+        action: () => handleOpenShareTarget(`sms:?&body=${encodedMessage}`, { sameTab: true }),
+      },
+    ];
+  }, [handleOpenShareTarget, shareDetails]);
 
   return (
     <div 
@@ -27,9 +181,16 @@ export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onCl
       >
         <div className="relative">
           <img src={photoUrl} alt={`Photo from ${match.homeTeam.name} vs ${match.awayTeam.name}`} className="w-full h-auto max-h-[70vh] object-contain rounded-t-xl" />
-          <button 
-            onClick={onClose} 
-            className="absolute top-3 right-3 p-1.5 rounded-full text-white bg-black/50 hover:bg-black/70" 
+          <button
+            onClick={handleShareClick}
+            className="absolute top-3 left-3 p-1.5 rounded-full text-white bg-black/50 hover:bg-black/70"
+            aria-label="Share matchday memory"
+          >
+            <ShareIcon className="w-6 h-6" />
+          </button>
+          <button
+            onClick={onClose}
+            className="absolute top-3 right-3 p-1.5 rounded-full text-white bg-black/50 hover:bg-black/70"
             aria-label="Close"
           >
             <XMarkIcon className="w-6 h-6" />
@@ -44,7 +205,7 @@ export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onCl
               <span className="text-primary font-bold">{match.scores.home}</span>
             </div>
             <span className="text-text-subtle font-bold">vs</span>
-             <div className="flex items-center gap-2 truncate justify-end">
+            <div className="flex items-center gap-2 truncate justify-end">
               <span className="text-primary font-bold">{match.scores.away}</span>
               <span className="font-semibold">{match.awayTeam.name}</span>
               <TeamLogo teamId={match.awayTeam.id} teamName={match.awayTeam.name} size="small" />
@@ -53,6 +214,34 @@ export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onCl
           <p className="text-xs text-text-subtle text-center mt-2">
             {match.venue} &bull; Attended on {new Date(attendedOn).toLocaleDateString()}
           </p>
+          {(isShareMenuOpen || copyState === 'copied' || copyState === 'error') && (
+            <div className="mt-4 border-t border-border pt-4">
+              <p className="text-sm font-semibold text-text">Share this memory</p>
+              <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {shareTargets.map(target => (
+                  <button
+                    key={target.label}
+                    onClick={target.action}
+                    className="rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:border-primary/60 hover:text-primary transition-colors"
+                  >
+                    {target.label}
+                  </button>
+                ))}
+                <button
+                  onClick={handleCopyLink}
+                  className="rounded-lg border border-dashed border-border px-3 py-2 text-sm font-medium text-text hover:border-primary/60 hover:text-primary transition-colors"
+                >
+                  {copyState === 'copied' ? 'Link copied!' : copyState === 'error' ? 'Copy failed' : 'Copy link'}
+                </button>
+                <button
+                  onClick={handleDownloadPhoto}
+                  className="rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:border-primary/60 hover:text-primary transition-colors"
+                >
+                  Download photo
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/StatsView.tsx
+++ b/components/StatsView.tsx
@@ -1,9 +1,11 @@
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { AttendedMatch, User } from '../types';
 import { TEAMS } from '../services/mockData';
 import { TeamLogo } from './TeamLogo';
 import { ShareIcon, ShieldCheckIcon, UserCircleIcon } from './Icons';
+import { attemptShare, getAppShareUrl } from '../utils/share';
+import type { ShareOutcome } from '../utils/share';
 
 interface StatsViewProps {
     attendedMatches: AttendedMatch[];
@@ -71,6 +73,38 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
         };
     }, [attendedMatches]);
 
+    const [shareFeedback, setShareFeedback] = useState<'idle' | ShareOutcome>('idle');
+
+    const handleShareStats = async () => {
+        if (!stats) return;
+
+        const shareUrl = getAppShareUrl();
+        const shareText = `I've logged ${stats.totalMatches} matches, ${stats.totalGrounds} grounds and ${stats.totalPoints} total points this season on The Scrum Book.`;
+
+        const outcome = await attemptShare({
+            title: `${user.name}'s rugby league stats`,
+            text: shareText,
+            url: shareUrl,
+            clipboardFallbackText: `${shareText} Keep up with me at ${shareUrl}`,
+        });
+
+        setShareFeedback(outcome);
+        setTimeout(() => setShareFeedback('idle'), 2500);
+    };
+
+    const renderShareFeedbackMessage = () => {
+        if (shareFeedback === 'copied') {
+            return 'Link copied!';
+        }
+        if (shareFeedback === 'shared') {
+            return 'Share sheet opened';
+        }
+        if (shareFeedback === 'failed') {
+            return 'Sharing unavailable';
+        }
+        return '';
+    };
+
     if (!stats) {
         return (
             <div className="text-center py-20 bg-surface rounded-xl">
@@ -80,13 +114,27 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
         );
     }
 
+    const shareFeedbackMessage = renderShareFeedbackMessage();
+
     return (
         <div className="space-y-6 text-text-strong">
-             <div className="flex justify-between items-center">
+             <div className="flex justify-between items-center gap-3">
                 <h1 className="text-xl font-bold">The Scrum Book</h1>
-                <button className="p-2 text-text-subtle hover:text-primary">
-                    <ShareIcon className="w-6 h-6"/>
-                </button>
+                <div className="flex flex-col items-end gap-1">
+                    <button
+                        type="button"
+                        onClick={handleShareStats}
+                        className="p-2 text-text-subtle hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
+                        aria-label="Share my stats"
+                    >
+                        <ShareIcon className="w-6 h-6"/>
+                    </button>
+                    {shareFeedbackMessage && (
+                        <span className="text-[11px] font-semibold text-text-subtle" role="status" aria-live="polite">
+                            {shareFeedbackMessage}
+                        </span>
+                    )}
+                </div>
             </div>
 
             <div className="flex items-center gap-4">

--- a/utils/share.ts
+++ b/utils/share.ts
@@ -1,0 +1,56 @@
+export type ShareOutcome = 'shared' | 'copied' | 'failed';
+
+export interface ShareContent {
+  title: string;
+  text: string;
+  url?: string;
+  clipboardFallbackText?: string;
+}
+
+const getClipboardPayload = ({ text, url, clipboardFallbackText }: ShareContent) => {
+  if (clipboardFallbackText) {
+    return clipboardFallbackText;
+  }
+
+  if (text && url) {
+    return `${text} ${url}`.trim();
+  }
+
+  return text || url || '';
+};
+
+export const attemptShare = async (content: ShareContent): Promise<ShareOutcome> => {
+  if (typeof navigator !== 'undefined' && 'share' in navigator) {
+    try {
+      await (navigator as Navigator & { share: (data: ShareData) => Promise<void> }).share({
+        title: content.title,
+        text: content.text,
+        url: content.url,
+      });
+      return 'shared';
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return 'shared';
+      }
+    }
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(getClipboardPayload(content));
+      return 'copied';
+    } catch {
+      // no-op fallthrough
+    }
+  }
+
+  return 'failed';
+};
+
+export const getAppShareUrl = () => {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return 'https://thescrumbook.com';
+};


### PR DESCRIPTION
## Summary
- add share targets for X, Telegram, Messenger, and SMS to the photo viewer modal fallback menu
- close the share menu after launching a share target and add a download button that names files after the match
- improve email/SMS handling by opening them in the current tab for mobile support and adjust the grid layout for the expanded actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb7cab188832cbb83760fe4bc0010