### PR TITLE
Improve nearby match distance readability

### DIFF
--- a/components/MatchListItem.tsx
+++ b/components/MatchListItem.tsx
@@ -13,6 +13,7 @@ import { TeamLogo } from './TeamLogo';
 import { ALL_VENUES } from '../services/mockData';
 import { getDistance } from '../utils/geolocation';
 import { formatDateUK } from '../utils/date';
+import { attemptShare, getAppShareUrl, type ShareOutcome } from '../utils/share';
 
 interface MatchListItemProps {
   match: Match;
@@ -264,8 +265,8 @@ export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended,
             <span>{formatDateUK(match.startTime)}</span>
           </div>
           {distance !== undefined && (
-            <div className="font-semibold text-primary">
-              <span>{distance.toFixed(1)} mi away</span>
+            <div className="flex items-center gap-1.5 rounded-full bg-surface px-2.5 py-1 text-xs font-semibold text-text-strong shadow-sm ring-1 ring-border/60">
+              <span className="tracking-tight">{distance.toFixed(1)} mi away</span>
             </div>
           )}
         </div>

--- a/components/StatsView.tsx
+++ b/components/StatsView.tsx
@@ -5,6 +5,7 @@ import { TEAMS } from '../services/mockData';
 import { TeamLogo } from './TeamLogo';
 import { ShareIcon, ShieldCheckIcon, UserCircleIcon } from './Icons';
 import { formatDateUK } from '../utils/date';
+import { attemptShare, getAppShareUrl, type ShareOutcome } from '../utils/share';
 
 interface StatsViewProps {
     attendedMatches: AttendedMatch[];


### PR DESCRIPTION
## Summary
- display nearby match distance values in a high-contrast pill for better readability on themed cards
- import the sharing utilities in match list and stats components so TypeScript builds succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffaabbabc832c9e7c092761f3c0b3