### PR TITLE
Add Node.js server scaffold

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "firebase-admin": "^12.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `server` workspace with Node.js package metadata and dependencies
- implement a basic Express server entry point responding on port 3001

## Testing
- npm install express cors firebase-admin *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ae80bdc4832c94da2cf3d4786283