### PR TITLE
Initialize Firebase Admin in server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "dev:server": "node server/index.js",
     "firebase:login": "firebase login",
     "firebase:serve": "firebase emulators:start --only hosting",
     "firebase:deploy": "npm run build && firebase deploy --only hosting"

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const cors = require('cors');
+const admin = require('firebase-admin');
+
+const requiredEnvVars = [
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_CLIENT_EMAIL',
+  'FIREBASE_PRIVATE_KEY',
+];
+
+const missingVars = requiredEnvVars.filter((name) => !process.env[name]);
+
+if (missingVars.length > 0) {
+  throw new Error(
+    `Missing required Firebase credentials in environment variables: ${missingVars.join(', ')}`,
+  );
+}
+
+const serviceAccount = {
+  type: process.env.FIREBASE_TYPE,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  privateKeyId: process.env.FIREBASE_PRIVATE_KEY_ID,
+  privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+  clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+  clientId: process.env.FIREBASE_CLIENT_ID,
+  authUri: process.env.FIREBASE_AUTH_URI,
+  tokenUri: process.env.FIREBASE_TOKEN_URI,
+  authProviderX509CertUrl: process.env.FIREBASE_AUTH_PROVIDER_X509_CERT_URL,
+  clientX509CertUrl: process.env.FIREBASE_CLIENT_X509_CERT_URL,
+  universeDomain: process.env.FIREBASE_UNIVERSE_DOMAIN,
+};
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  });
+}
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "firebase-admin": "^12.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize the Firebase Admin SDK in the Express server using environment-provided service account credentials
- add a root npm script to run the server with `node server/index.js`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ae80bdc4832c94da2cf3d4786283