### PR TITLE
Port shared modules into Next.js app

### DIFF
--- a/the-scrum-book-nextjs/src/badges.ts
+++ b/the-scrum-book-nextjs/src/badges.ts
@@ -1,0 +1,176 @@
+import type { Badge, AttendedMatch, User } from '@/types';
+import {
+    TrophyIcon,
+    CheckCircleIcon,
+    LocationMarkerIcon,
+    MapIcon,
+    ShareIcon,
+    SparklesIcon,
+    StarIcon,
+    ShieldCheckIcon,
+    Squares2X2Icon,
+} from '@/components/Icons';
+import { teamIdToVenue } from '@/services/mockData';
+
+export const allBadges: Badge[] = [
+    {
+        id: 'FIRST_MATCH',
+        name: 'First Kick-Off',
+        description: 'You attended your first Super League match!',
+        icon: TrophyIcon,
+        category: 'Milestone',
+    },
+    {
+        id: 'TEN_GAMES',
+        name: 'Super Fan',
+        description: 'You have attended 10 matches.',
+        icon: CheckCircleIcon,
+        category: 'Milestone',
+    },
+    {
+        id: 'FIVE_STADIUMS',
+        name: 'On Tour',
+        description: 'You have visited 5 different stadiums.',
+        icon: LocationMarkerIcon,
+        category: 'Milestone',
+    },
+    {
+        id: 'FRENCH_TRIP',
+        name: 'French Connection',
+        description: 'You attended a match in France!',
+        icon: MapIcon,
+        category: 'Milestone',
+    },
+    {
+        id: 'AWAY_DAYS',
+        name: 'Away Day Tripper',
+        description: 'You attended 3 away matches supporting your team.',
+        icon: ShareIcon,
+        category: 'Milestone',
+    },
+     {
+        id: 'CLUB_COLLECTOR',
+        name: 'Club Collector',
+        description: 'You have seen all Super League teams play.',
+        icon: Squares2X2Icon,
+        category: 'Milestone',
+    },
+    {
+        id: 'HOME_GROUND',
+        name: 'True Supporter',
+        description: "You attended a match at your favorite team's home ground!",
+        icon: ShieldCheckIcon,
+        category: 'Milestone',
+    },
+    {
+        id: 'DERBY_DAY',
+        name: 'Derby Day Specialist',
+        description: 'You attended a major derby match.',
+        icon: TrophyIcon,
+        category: 'Tournament',
+    },
+    {
+        id: 'MAGIC_WEEKEND',
+        name: 'Magic Weekend',
+        description: 'You attended a Magic Weekend event!',
+        icon: SparklesIcon,
+        category: 'Tournament',
+    },
+    {
+        id: 'GRAND_FINAL',
+        name: 'Grand Final Fan',
+        description: 'You attended a Super League Grand Final!',
+        icon: StarIcon,
+        category: 'Tournament',
+    },
+];
+
+const DERBY_TEAMS = [
+    ['Wigan Warriors', 'St Helens'],
+    ['Hull FC', 'Hull KR'],
+    ['Leeds Rhinos', 'Bradford Bulls'], // Classic rivalry
+    ['Warrington Wolves', 'Widnes Vikings'],
+    ['Castleford Tigers', 'Wakefield Trinity'],
+];
+
+const hasAttendedDerby = (attendedMatches: AttendedMatch[]): boolean => {
+    return attendedMatches.some(({ match }) => {
+        const teamNames = [match.homeTeam.name, match.awayTeam.name];
+        return DERBY_TEAMS.some(derbyPair => 
+            teamNames.includes(derbyPair[0]) && teamNames.includes(derbyPair[1])
+        );
+    });
+};
+
+export const checkAndAwardBadges = (
+    attendedMatches: AttendedMatch[],
+    earnedBadgeIds: string[],
+    user: User,
+): string[] => {
+    const newlyEarned: string[] = [];
+    
+    // Check for 'First Kick-Off'
+    if (attendedMatches.length >= 1 && !earnedBadgeIds.includes('FIRST_MATCH')) {
+        newlyEarned.push('FIRST_MATCH');
+    }
+    
+    // Check for 'Super Fan'
+    if (attendedMatches.length >= 10 && !earnedBadgeIds.includes('TEN_GAMES')) {
+        newlyEarned.push('TEN_GAMES');
+    }
+    
+    // Check for 'On Tour'
+    const uniqueVenues = new Set(attendedMatches.map(am => am.match.venue));
+    if (uniqueVenues.size >= 5 && !earnedBadgeIds.includes('FIVE_STADIUMS')) {
+        newlyEarned.push('FIVE_STADIUMS');
+    }
+    
+    // Check for 'Derby Day Specialist'
+    if (hasAttendedDerby(attendedMatches) && !earnedBadgeIds.includes('DERBY_DAY')) {
+        newlyEarned.push('DERBY_DAY');
+    }
+
+    // Check for 'True Supporter'
+    if (user.favoriteTeamId && !earnedBadgeIds.includes('HOME_GROUND')) {
+        const homeGround = teamIdToVenue[user.favoriteTeamId];
+        if (homeGround && attendedMatches.some(am => am.match.venue === homeGround)) {
+            newlyEarned.push('HOME_GROUND');
+        }
+    }
+
+    // Check for 'French Connection' (Catalans' home ground)
+    if (attendedMatches.some(am => am.match.venue === 'Stade Gilbert Brutus') && !earnedBadgeIds.includes('FRENCH_TRIP')) {
+        newlyEarned.push('FRENCH_TRIP');
+    }
+
+    // Check for 'Away Day Tripper'
+    if (user.favoriteTeamId && !earnedBadgeIds.includes('AWAY_DAYS')) {
+        const awayMatchCount = attendedMatches.filter(am => am.match.awayTeam.id === user.favoriteTeamId).length;
+        if (awayMatchCount >= 3) {
+            newlyEarned.push('AWAY_DAYS');
+        }
+    }
+    
+    // Check for 'Magic Weekend'
+    if (attendedMatches.some(am => am.match.venue === "St James' Park") && !earnedBadgeIds.includes('MAGIC_WEEKEND')) {
+        newlyEarned.push('MAGIC_WEEKEND');
+    }
+
+    // Check for 'Grand Final Fan'
+    if (attendedMatches.some(am => am.match.venue === 'Old Trafford') && !earnedBadgeIds.includes('GRAND_FINAL')) {
+        newlyEarned.push('GRAND_FINAL');
+    }
+
+    // Check for 'Club Collector'
+    const totalTeams = 12; // There are 12 teams in the Super League
+    const seenTeams = new Set<string>();
+    attendedMatches.forEach(am => {
+        if(am.match.homeTeam.id) seenTeams.add(am.match.homeTeam.id);
+        if(am.match.awayTeam.id) seenTeams.add(am.match.awayTeam.id);
+    });
+    if (seenTeams.size >= totalTeams && !earnedBadgeIds.includes('CLUB_COLLECTOR')) {
+        newlyEarned.push('CLUB_COLLECTOR');
+    }
+
+    return newlyEarned;
+};

--- a/the-scrum-book-nextjs/src/components/AboutView.tsx
+++ b/the-scrum-book-nextjs/src/components/AboutView.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import React from 'react';
+import {
+  LogoIcon,
+  SparklesIcon,
+  UsersIcon,
+  ListBulletIcon,
+  CalendarIcon,
+  ChartBarIcon,
+  PencilIcon,
+  TrophyIcon,
+  } from './Icons';
+
+interface HighlightCard {
+  title: string;
+  description: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  accent: string;
+  footer?: string;
+}
+
+interface FeatureColumn {
+  title:string;
+  items: string[];
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+interface FeatureCard {
+  title: string;
+  summary: string;
+  focus: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+const highlightCards: HighlightCard[] = [
+  {
+    title: 'Your Digital Match Day Diary',
+    description: 'The Scrum Book is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
+    icon: SparklesIcon,
+    accent: 'from-primary/80 to-secondary/70',
+    footer: 'Never forget a match day memory.',
+  },
+  {
+    title: 'Connect with the Community',
+    description: 'Find and connect with other fans, see their match history, and share your passion for the game.',
+    icon: UsersIcon,
+    accent: 'from-secondary/70 to-accent/80',
+    footer: 'Build your network of fellow supporters.',
+  },
+  {
+    title: 'Unlock Achievements',
+    description: 'Earn badges for your dedication, from visiting new grounds to attending classic derby clashes and major finals.',
+    icon: TrophyIcon,
+    accent: 'from-accent/80 to-primary/80',
+    footer: 'Show off your commitment as a super fan.',
+  },
+];
+
+const featureColumns: FeatureColumn[] = [
+  {
+    title: 'Core Features',
+    icon: PencilIcon,
+    items: [
+      'Log every match you attend with a single click.',
+      'View upcoming fixtures and past results for the season.',
+      'See the live Super League table with team form guides.',
+      'Explore community insights shared by fellow supporters.',
+    ],
+  },
+  {
+    title: 'Personalized Experience',
+    icon: ChartBarIcon,
+    items: [
+      'Track your personal stats, including total matches and unique venues.',
+      'Find nearby matches based on your current location.',
+      'Set your favorite team for a more tailored experience.',
+      'Upload photos to your attended matches to create a visual diary.',
+    ],
+  },
+];
+
+const featureCards: FeatureCard[] = [
+  {
+    title: 'My Matches',
+    summary: 'A complete history of every game you’ve attended, with the ability to add photos and relive the memories.',
+    focus: 'Filter by year or competition to easily find past games.',
+    icon: ListBulletIcon,
+  },
+  {
+    title: 'Stats & Badges',
+    summary: 'See a detailed breakdown of your support, from your most-visited grounds to your most-watched teams.',
+    focus: 'Unlock a variety of badges that celebrate your dedication as a fan.',
+    icon: ChartBarIcon,
+  },
+  {
+    title: 'Community Hub',
+    summary: 'Connect with other rugby league fans, swap match stories, and compare attendance streaks.',
+    focus: 'Discover new grounds and fixtures through the crowd’s recommendations.',
+    icon: UsersIcon,
+  },
+];
+
+const getStartedSteps: string[] = [
+  'Create your profile with a single click to start your collection.',
+  'Browse the fixtures and mark any matches you have attended in the past.',
+  'Upload photos to your attended matches to create a visual diary.',
+  'Check out the "Grounds" view to see which stadiums are closest to you.',
+  'Join the community hub to share tips, photos, and matchday highlights.',
+];
+
+interface AboutViewProps {
+  theme: 'light' | 'dark';
+}
+
+export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
+  return (
+    <div className="space-y-12">
+      <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-surface shadow-card dark:border-white/10">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-accent/10 to-secondary/10" />
+        <div className="relative grid gap-10 px-6 py-12 md:grid-cols-[1.1fr,0.9fr] md:px-12">
+          <div>
+            <div className="mb-6 flex items-center gap-3 text-primary">
+              <LogoIcon className="h-10 w-10" theme={theme} />
+              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+            </div>
+            <h1 className="text-4xl font-bold text-text-strong md:text-5xl">
+              Your Ultimate Rugby League Companion
+            </h1>
+            <p className="mt-5 max-w-2xl text-lg text-text">
+              The Scrum Book is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-4 text-sm">
+              <div className="flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 font-semibold text-primary">
+                <SparklesIcon className="h-4 w-4" />
+                Track Attended Matches
+              </div>
+              <div className="flex items-center gap-2 rounded-full bg-secondary/10 px-4 py-2 font-semibold text-secondary">
+                <CalendarIcon className="h-4 w-4" />
+                Explore Fixtures &amp; Results
+              </div>
+              <div className="flex items-center gap-2 rounded-full bg-accent/10 px-4 py-2 font-semibold text-accent">
+                <TrophyIcon className="h-4 w-4" />
+                Earn Fan Badges
+              </div>
+            </div>
+          </div>
+          <div className="relative">
+            <div className="absolute -top-10 -right-6 h-40 w-40 rounded-full bg-secondary/20 blur-3xl" />
+            <div className="relative rounded-2xl border border-border/70 bg-gradient-to-br from-surface-alt via-surface to-surface-alt p-6 shadow-card">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-subtle">Key Features</h2>
+              <ul className="mt-4 space-y-3 text-sm text-text">
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">1</span>
+                  <div>
+                    <p className="font-semibold text-text-strong">Personal Match Log</p>
+                    <p>Build a comprehensive history of every game you've seen live.</p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-secondary/10 font-semibold text-secondary">2</span>
+                  <div>
+                    <p className="font-semibold text-text-strong">Fan Statistics</p>
+                    <p>Get insights into your support with personalized stats and data.</p>
+                  </div>
+                </li>
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent/10 font-semibold text-accent">3</span>
+                  <div>
+                    <p className="font-semibold text-text-strong">Community Hub</p>
+                    <p>Connect with other fans and see how your attendance record compares.</p>
+                  </div>
+                </li>
+              </ul>
+              <div className="mt-6 rounded-2xl bg-primary/10 p-4 text-sm text-primary">
+                <p className="font-semibold uppercase tracking-[0.15em]">Built for the fans</p>
+                <p className="mt-1 text-primary/90">This app is made by a fan, for the fans, to celebrate our shared love of the game.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {highlightCards.map((card) => {
+          const Icon = card.icon;
+          return (
+            <article
+              key={card.title}
+              className="rounded-2xl border border-border/60 bg-surface p-6 shadow-card transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div className={`inline-flex items-center justify-center rounded-xl bg-gradient-to-br ${card.accent} p-3 text-white shadow-inner`}>
+                <Icon className="h-5 w-5" />
+              </div>
+              <h3 className="mt-4 text-xl font-semibold text-text-strong">{card.title}</h3>
+              <p className="mt-2 text-sm text-text">{card.description}</p>
+              {card.footer && <p className="mt-4 text-xs font-medium uppercase tracking-wide text-text-subtle">{card.footer}</p>}
+            </article>
+          );
+        })}
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {featureColumns.map((column) => {
+          const Icon = column.icon;
+          return (
+            <div key={column.title} className="rounded-3xl border border-border/70 bg-surface-alt/60 p-6 shadow-card">
+              <div className="flex items-center gap-3">
+                <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <h3 className="text-xl font-semibold text-text-strong">{column.title}</h3>
+              </div>
+              <ul className="mt-4 space-y-3 text-sm text-text">
+                {column.items.map((item) => (
+                  <li key={item} className="flex gap-3">
+                    <span className="mt-1 inline-block h-2 w-2 rounded-full bg-primary" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </section>
+
+      <section className="rounded-3xl border border-border/80 bg-surface p-8 shadow-card">
+        <h2 className="text-2xl font-bold text-text-strong">Explore Every Feature</h2>
+        <p className="mt-2 max-w-2xl text-text">
+          Dive into the different sections of the app to get the most out of your experience. Each part is designed to enhance your journey as a rugby league supporter.
+        </p>
+        <div className="mt-6 grid gap-6 md:grid-cols-3">
+          {featureCards.map((feature) => {
+            const Icon = feature.icon;
+            return (
+              <div key={feature.title} className="rounded-2xl border border-border/70 bg-surface-alt/60 p-5">
+                <div className="flex items-center gap-3">
+                  <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-secondary/10 text-secondary">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-text-strong">{feature.title}</h3>
+                </div>
+                <p className="mt-3 text-sm text-text">{feature.summary}</p>
+                <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-text-subtle">{feature.focus}</p>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-primary/30 bg-primary/5 p-8 shadow-card">
+        <h2 className="text-2xl font-bold text-text-strong">Get Started in Minutes</h2>
+        <ul className="mt-4 grid gap-4 text-sm text-text md:grid-cols-2">
+          {getStartedSteps.map((item) => (
+            <li key={item} className="flex items-start gap-3 rounded-2xl border border-primary/20 bg-surface/70 p-4 shadow-sm">
+              <div className="mt-1 h-6 w-6 rounded-full bg-primary/15 text-center text-sm font-semibold leading-6 text-primary">✓</div>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="rounded-3xl border border-border/80 bg-surface-alt/80 p-8 text-center shadow-card">
+        <h2 className="text-2xl font-bold text-text-strong">Join The Scrum Book Community</h2>
+        <p className="mt-2 text-text">
+          Start building your fan legacy today. The Scrum Book is your home for all your rugby league memories and connections.
+        </p>
+        <p className="mt-4 text-sm font-medium uppercase tracking-[0.2em] text-text-subtle">
+          Track. Share. Celebrate.
+        </p>
+      </section>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/AvatarModal.tsx
+++ b/the-scrum-book-nextjs/src/components/AvatarModal.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { XMarkIcon, ArrowUpTrayIcon, UserCircleIcon } from './Icons';
+
+interface AvatarModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (avatarUrl: string) => void;
+  currentAvatar?: string;
+}
+
+export const AvatarModal: React.FC<AvatarModalProps> = ({ isOpen, onClose, onSave, currentAvatar }) => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  useEffect(() => {
+    if (isOpen) {
+        setPreviewUrl(currentAvatar || null);
+    }
+  }, [isOpen, currentAvatar]);
+
+  if (!isOpen) return null;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreviewUrl(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+  
+  const handleSave = () => {
+    if (previewUrl) {
+      onSave(previewUrl);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="avatar-modal-title">
+      <div className="bg-surface rounded-xl shadow-lg w-full max-w-md max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 id="avatar-modal-title" className="text-xl font-bold text-text-strong">Edit Avatar</h2>
+          <button onClick={onClose} className="p-1 rounded-full text-text-subtle hover:bg-surface-alt" aria-label="Close">
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto space-y-4">
+            <div className="flex items-center justify-center w-32 h-32 mx-auto rounded-full bg-surface-alt border-2 border-dashed border-border overflow-hidden">
+                {previewUrl ? (
+                    <img src={previewUrl} alt="Avatar preview" className="w-full h-full object-cover" />
+                ) : (
+                    <UserCircleIcon className="w-24 h-24 text-text-subtle/30" />
+                )}
+            </div>
+            
+            <div>
+                <input type="file" accept="image/*" ref={fileInputRef} onChange={handleFileChange} className="hidden" />
+                <button 
+                    onClick={() => fileInputRef.current?.click()}
+                    className="w-full flex items-center justify-center gap-2 text-center bg-primary/10 text-primary font-semibold py-2 px-4 rounded-md hover:bg-primary/20 transition-colors"
+                >
+                    <ArrowUpTrayIcon className="w-5 h-5"/>
+                    Choose an Image
+                </button>
+            </div>
+        </div>
+
+        <div className="p-4 bg-surface-alt border-t border-border mt-auto">
+            <button 
+                onClick={handleSave}
+                disabled={!previewUrl}
+                className="w-full bg-secondary text-white font-semibold py-2.5 px-4 rounded-md hover:bg-secondary/90 transition-colors disabled:bg-secondary/50 disabled:cursor-not-allowed"
+            >
+                Save Avatar
+            </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/BadgesView.tsx
+++ b/the-scrum-book-nextjs/src/components/BadgesView.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+
+import React from 'react';
+import type { Badge } from '@/types';
+import { TrophyIcon } from './Icons';
+
+interface BadgesViewProps {
+    allBadges: Badge[];
+    earnedBadgeIds: string[];
+}
+
+const BadgeCard: React.FC<{ badge: Badge; isEarned: boolean }> = ({ badge, isEarned }) => {
+    const Icon = badge.icon;
+    return (
+        <div 
+            key={badge.id}
+            className={`p-4 rounded-xl flex flex-col items-center text-center transition-all duration-300 ${
+                isEarned ? 'bg-surface shadow-card' : 'bg-surface-alt opacity-60'
+            }`}
+        >
+            <div className={`flex-shrink-0 w-14 h-14 rounded-full flex items-center justify-center mb-3 ${
+                isEarned ? 'bg-accent/20' : 'bg-border/20'
+            }`}>
+                <Icon className={`w-7 h-7 ${isEarned ? 'text-accent' : 'text-text-subtle'}`} />
+            </div>
+            <h2 className={`font-bold text-sm mb-1 ${
+                isEarned ? 'text-text-strong' : 'text-text-subtle'
+            }`}>{badge.name}</h2>
+            <p className={`text-xs flex-grow ${isEarned ? 'text-text' : 'text-text-subtle'}`}>
+                {badge.description}
+            </p>
+        </div>
+    );
+};
+
+export const BadgesView: React.FC<BadgesViewProps> = ({ allBadges, earnedBadgeIds }) => {
+    
+    const earnedCount = earnedBadgeIds.length;
+    const totalCount = allBadges.length;
+
+    const milestones = allBadges.filter(b => b.category === 'Milestone');
+    const tournaments = allBadges.filter(b => b.category === 'Tournament');
+
+    return (
+        <div className="space-y-8">
+            <div className="flex items-center justify-between pb-4 border-b border-border">
+                <h1 className="text-3xl font-bold text-text-strong">Badge Collection</h1>
+                <div className="text-lg font-semibold text-text-subtle">
+                    <TrophyIcon className="w-5 h-5 inline-block mr-2 text-accent" />
+                    {earnedCount} / {totalCount} Unlocked
+                </div>
+            </div>
+
+            {milestones.length > 0 && (
+                <section>
+                    <h2 className="text-xl font-bold text-text-strong uppercase tracking-wider mb-4">Milestones</h2>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                        {milestones.map(badge => (
+                           <BadgeCard key={badge.id} badge={badge} isEarned={earnedBadgeIds.includes(badge.id)} />
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {tournaments.length > 0 && (
+                 <section>
+                    <h2 className="text-xl font-bold text-text-strong uppercase tracking-wider mb-4 mt-8">Tournaments</h2>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                        {tournaments.map(badge => (
+                           <BadgeCard key={badge.id} badge={badge} isEarned={earnedBadgeIds.includes(badge.id)} />
+                        ))}
+                    </div>
+                </section>
+            )}
+
+             {earnedCount < totalCount && (
+                <div className="text-center py-10 bg-surface rounded-md mt-8 shadow-card">
+                    <h2 className="text-xl font-bold text-text-strong">Keep Going!</h2>
+                    <p className="text-text-subtle mt-2">Attend more matches to unlock the remaining badges and complete your collection.</p>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/CommunityView.tsx
+++ b/the-scrum-book-nextjs/src/components/CommunityView.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { UsersIcon, ArrowRightOnRectangleIcon } from './Icons';
+
+export const CommunityView: React.FC = () => {
+  const { currentUser } = useAuth();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3 border-b border-border pb-4">
+        <UsersIcon className="w-8 h-8 text-primary" />
+        <div>
+          <h1 className="text-3xl font-bold text-text-strong">Community Hub</h1>
+          <p className="text-text-subtle mt-1">Connect your Firebase project to unlock shared supporter profiles.</p>
+        </div>
+      </div>
+
+      <div className="bg-surface rounded-xl shadow-card p-8 text-center space-y-4 border border-dashed border-border">
+        <p className="text-lg text-text-subtle">Coming Soon.</p>
+        {!currentUser && (
+          <div className="flex items-center justify-center gap-3 text-text-subtle">
+            <ArrowRightOnRectangleIcon className="w-5 h-5" />
+            <span>Sign in once Firebase is configured to join the community.</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/DataUploader.tsx
+++ b/the-scrum-book-nextjs/src/components/DataUploader.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import { mockMatches, mockLeagueTable } from '@/services/mockData';
+import { ServerIcon, AlertTriangleIcon } from './Icons';
+
+export const DataUploader: React.FC = () => {
+  return (
+    <div className="bg-surface p-6 md:p-8 rounded-md shadow-card max-w-2xl mx-auto">
+      <div className="flex items-center gap-4 mb-6 border-b border-border pb-4">
+        <ServerIcon className="w-10 h-10 text-primary" />
+        <h1 id="data-uploader-title" className="text-3xl font-bold text-text-strong">
+          Admin: Data Management
+        </h1>
+      </div>
+
+      <p className="text-text-subtle mb-6">
+        The Scrum Book runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
+      </p>
+
+      <div className="rounded-md border border-warning/30 bg-warning/10 p-4 text-warning flex items-center gap-3">
+        <AlertTriangleIcon className="w-6 h-6" />
+        <p className="font-semibold">
+          Firebase is disabled in this build. Add environment variables and reinstall dependencies to sync the {mockMatches.length}{' '}
+          matches and {mockLeagueTable.length} league standings to Firestore.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/DesktopTopBar.tsx
+++ b/the-scrum-book-nextjs/src/components/DesktopTopBar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import type { View } from '@/types';
+import { mainNavigationItems } from './navigationItems';
+import { ArrowLeftIcon } from './Icons';
+
+interface DesktopTopBarProps {
+  currentView: View;
+  setView: (view: View) => void;
+}
+
+export const DesktopTopBar: React.FC<DesktopTopBarProps> = ({ currentView, setView }) => {
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      setView('UPCOMING');
+    }
+  };
+
+  return (
+    <nav className="hidden md:flex fixed inset-x-0 top-0 z-30 border-b border-border/70 bg-surface/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center gap-4 px-6 py-3">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="flex items-center gap-2 rounded-full border border-border/70 bg-surface-alt/70 px-3 py-2 text-sm font-semibold text-text-subtle transition-colors hover:border-border hover:text-text"
+          aria-label="Go back"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          <span>Back</span>
+        </button>
+        <div className="h-6 w-px bg-border/60" aria-hidden="true" />
+        <ul className="flex flex-wrap items-center gap-1.5">
+          {mainNavigationItems.map(({ label, view }) => {
+            const isActive = currentView === view;
+            return (
+              <li key={view}>
+                <button
+                  type="button"
+                  onClick={() => setView(view)}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors ${
+                    isActive
+                      ? 'bg-primary/15 text-primary border border-primary/40 shadow-sm'
+                      : 'text-text-subtle hover:text-text hover:bg-surface-alt/80 border border-transparent'
+                  }`}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/ErrorDisplay.tsx
+++ b/the-scrum-book-nextjs/src/components/ErrorDisplay.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+
+import React from 'react';
+import { AlertTriangleIcon } from './Icons';
+
+interface ErrorDisplayProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ message, onRetry }) => {
+  return (
+    <div className="bg-surface p-8 rounded-md text-center flex flex-col items-center shadow-card">
+        <AlertTriangleIcon className="w-12 h-12 text-danger mb-4" />
+        <h2 className="text-xl font-bold text-text-strong mb-2">An Error Occurred</h2>
+        <p className="text-text-subtle mb-6">{message}</p>
+        <button
+            onClick={onRetry}
+            className="btn btn-primary bg-primary text-white font-semibold py-2 px-6 rounded-md hover:bg-primary/90 transition-colors duration-200"
+        >
+            Try Again
+        </button>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/Header.module.css
+++ b/the-scrum-book-nextjs/src/components/Header.module.css
@@ -1,0 +1,83 @@
+.backButton {
+  position: fixed;
+  top: 1.25rem;
+  left: 1.25rem;
+  z-index: 45;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(15, 23, 42, 0.88);
+  color: #ffffff;
+  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.75);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  cursor: pointer;
+}
+
+.backButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px -18px rgba(15, 23, 42, 0.85);
+}
+
+.backIcon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.logoButton {
+  position: fixed;
+  top: 1.25rem;
+  left: 4.5rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.logoIcon {
+  width: 3.75rem;
+  height: 3.75rem;
+}
+
+.menuButton {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(15, 23, 42, 0.88);
+  color: #ffffff;
+  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.75);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  cursor: pointer;
+}
+
+.menuButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px -18px rgba(15, 23, 42, 0.85);
+}
+
+.menuIcon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.backButton:focus-visible,
+.logoButton:focus-visible,
+.menuButton:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.8);
+  outline-offset: 3px;
+}

--- a/the-scrum-book-nextjs/src/components/Header.tsx
+++ b/the-scrum-book-nextjs/src/components/Header.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import { ArrowLeftIcon, LogoIcon, MenuIcon, XMarkIcon } from './Icons';
+import type { View } from '@/types';
+import styles from './Header.module.css';
+
+interface HeaderProps {
+  setView: (view: View) => void;
+  theme: string;
+  isMobileNavOpen: boolean;
+  onMobileNavToggle: () => void;
+}
+
+export const Header: React.FC<HeaderProps> = (props) => {
+  const { setView, theme, isMobileNavOpen, onMobileNavToggle } = props;
+  const themeMode = theme === 'dark' ? 'dark' : 'light';
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      setView('UPCOMING');
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`md:hidden ${styles.backButton}`}
+        onClick={handleBack}
+        aria-label="Go back"
+      >
+        <ArrowLeftIcon className={styles.backIcon} />
+      </button>
+      <button
+        type="button"
+        className={`md:hidden ${styles.logoButton}`}
+        onClick={() => setView('PROFILE')}
+        aria-label="Go to profile"
+      >
+        <LogoIcon className={styles.logoIcon} theme={themeMode} />
+      </button>
+      <button
+        type="button"
+        className={`md:hidden ${styles.menuButton}`}
+        onClick={onMobileNavToggle}
+        aria-label={isMobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'}
+        aria-expanded={isMobileNavOpen}
+      >
+        {isMobileNavOpen ? (
+          <XMarkIcon className={styles.menuIcon} />
+        ) : (
+          <MenuIcon className={styles.menuIcon} />
+        )}
+      </button>
+    </>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/Icons.tsx
+++ b/the-scrum-book-nextjs/src/components/Icons.tsx
@@ -1,0 +1,407 @@
+'use client';
+
+import React from 'react';
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+type ThemeMode = 'light' | 'dark';
+
+const logoSrc = `${import.meta.env.BASE_URL}logo.png`;
+const logoDarkSrc = `${import.meta.env.BASE_URL}logodark.png`;
+
+interface LogoIconProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  theme?: ThemeMode;
+}
+
+export const RugbyBallIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path d="M12.01,2.02c-5.5,0-9.99,3.58-9.99,8c0,4.42,4.49,8,9.99,8c5.5,0,9.99-3.58,9.99-8C22,5.6,17.51,2.02,12.01,2.02z M10.43,14.6l-3.32-1.92l1.66-2.88l3.32,1.92L10.43,14.6z M11.99,11.02l-3.32-1.92l1.66-2.88l3.32,1.92L11.99,11.02z M15.25,12.68l-3.32-1.92l1.66-2.88l3.32,1.92L15.25,12.68z"/>
+    </svg>
+);
+
+export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', alt, style, ...props }) => {
+  const resolvedSrc = theme === 'dark' ? logoDarkSrc : logoSrc;
+
+  return (
+    <img
+      src={resolvedSrc}
+      alt={alt ?? 'The Scrum Book logo'}
+      className={className}
+      loading="lazy"
+      style={{
+        objectFit: 'contain',
+        objectPosition: 'center',
+        ...style,
+      }}
+      {...props}
+    />
+  );
+};
+
+export const CalendarIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18.75z" />
+    </svg>
+);
+
+export const CalendarDaysIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0h18M10.5 12h3m-3 3.75h.008v.008h-.008v-.008zm0 0h.008v.008h-.008v-.008zm-2.25.008h.008v.008H8.25v-.008zm5.25 0h.008v.008h-.008v-.008zm-2.25 0h.008v.008h-.008v-.008zm5.25 0h.008v.008h-.008v-.008zm-4.5-3.75h.008v.008h-.008v-.008zm2.25 0h.008v.008h-.008v-.008z" />
+    </svg>
+);
+
+export const CheckCircleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
+
+export const PlusCircleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
+
+export const AlertTriangleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+    </svg>
+);
+
+export const TrashIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.134-2.09-2.134H8.09c-1.18 0-2.09.954-2.09 2.134v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+    </svg>
+);
+
+export const InformationCircleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+    </svg>
+);
+
+export const TrophyIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 18.75h-9a9 9 0 119 0zM16.5 18.75a9 9 0 00-9 0m9 0h.008v.008h-.008v-.008zm-9 0h-.008v.008h.008v-.008z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 12.75l.413-.413a1.5 1.5 0 012.122 0l.413.413m-2.948 0h2.948M9 3.75a.75.75 0 01.75-.75h4.5a.75.75 0 01.75.75v3.75m-6 0V3.75m6 0V7.5m-6 0h6m-3-3.75h.008v.008H12V3.75z" />
+    </svg>
+);
+
+export const ChartBarIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+    </svg>
+);
+
+export const TableCellsIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125v-1.5c0-.621.504-1.125 1.125-1.125h17.25c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h17.25m-17.25 0V4.5c0-.621.504-1.125 1.125-1.125h17.25c.621 0 1.125.504 1.125 1.125v13.875m-17.25 0h17.25M3.375 9h17.25M9 3.375v17.25m6-17.25v17.25" />
+    </svg>
+);
+
+export const SunIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.95-4.243l-1.591 1.591M5.25 12H3m4.243-4.95l-1.591-1.591M12 12a4.5 4.5 0 110-9 4.5 4.5 0 010 9z" />
+    </svg>
+);
+
+export const MoonIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+    </svg>
+);
+
+export const UserCircleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+);
+
+export const BuildingStadiumIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-18 0v8.25a2.25 2.25 0 002.25 2.25h13.5A2.25 2.25 0 0021 17.25V9" />
+    </svg>
+);
+
+export const LocationMarkerIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 21c4.5-4.8 7.5-8.1 7.5-11.25A7.5 7.5 0 0012 2.25a7.5 7.5 0 00-7.5 7.5C4.5 12.9 7.5 16.2 12 21z" />
+        <circle cx="12" cy="9.75" r="2.25" />
+    </svg>
+);
+
+export const NextSevenDaysIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" d="M8.25 7.5v2" />
+    <path strokeLinecap="round" d="M15.75 7.5v2" />
+    <rect x="7" y="9" width="10" height="7.5" rx="1.25" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10 11h3l-1.75 3" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M16.25 11.75l1.75 1.75-1.75 1.75" />
+    <path strokeLinecap="round" d="M17.5 13.5h-2.5" />
+  </svg>
+);
+
+export const NearbyIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.5c3.3-3.51 5.5-6.21 5.5-8.75a5.5 5.5 0 10-11 0c0 2.54 2.2 5.24 5.5 8.75z" />
+    <circle cx="12" cy="9.75" r="1.75" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.5 20.25h5" />
+  </svg>
+);
+
+export const FixturesResultsIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <rect x="6.75" y="8" width="10.5" height="8" rx="1.5" />
+    <path strokeLinecap="round" d="M12 8v8" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 10.5h2M13 13.5h2" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 13.5l1.25-1.25" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5l-1.25 1.25" />
+    <circle cx="12" cy="12" r="1.35" />
+  </svg>
+);
+
+export const LeagueTableChartIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" d="M7.25 15.5v-3.75M10.5 15.5v-6M13.75 15.5V9M17 15.5V11" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 17.5h12" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M7.25 11.75l2.5-2.5 2.25 2.25 3-3 2.75 2.25" />
+  </svg>
+);
+
+export const GroundsIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <rect x="6.75" y="7.75" width="10.5" height="8.5" rx="1.75" />
+    <path strokeLinecap="round" d="M6.75 12h10.5" />
+    <circle cx="12" cy="12" r="1.75" />
+    <path strokeLinecap="round" d="M9 7.75v8.5M15 7.75v8.5" />
+  </svg>
+);
+
+export const CommunityIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5c-2.35 0-4.25 1.14-4.25 2.5v.5" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5c2.35 0 4.25 1.14 4.25 2.5v.5" />
+    <circle cx="12" cy="11" r="2.5" />
+    <circle cx="7.75" cy="10" r="1.75" />
+    <circle cx="16.25" cy="10" r="1.75" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M7.75 17.5v-1.25c0-1.1.75-2.1 1.85-2.45" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M16.25 17.5v-1.25c0-1.1-.75-2.1-1.85-2.45" />
+  </svg>
+);
+
+export const CommunityHeartIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8 16.75c0-1.38 1.3-2.75 2.9-2.75.92 0 1.66.47 2.1 1.07.44-.6 1.18-1.07 2.1-1.07 1.6 0 2.9 1.37 2.9 2.75 0 2.23-2.34 3.65-5 5.25-2.66-1.6-5-3.02-5-5.25z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M7.25 11.75l1.25-2.25M16.75 11.75l-1.25-2.25" />
+    <circle cx="9" cy="9" r="1.5" />
+    <circle cx="15" cy="9" r="1.5" />
+  </svg>
+);
+
+export const AboutIcon: React.FC<IconProps> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5c-1.24 0-2.25.86-2.25 1.92 0 .7.41 1.28 1.05 1.61l.6.31c.58.3.9.76.9 1.31 0 .83-.67 1.5-1.5 1.5" />
+    <path strokeLinecap="round" d="M12 16.5h.01" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.5 18.5h5" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.5 12a3.5 3.5 0 10-5.74-3.85" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M14.5 5.75l.75-1.75" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.5 5.75L8.75 4" />
+  </svg>
+);
+
+export const UsersIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75c-3.728 0-6.75 1.77-6.75 3.25V21c0-2.485 3.022-4.5 6.75-4.5s6.75 2.015 6.75 4.5v1c0-1.48-3.022-3.25-6.75-3.25z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 13.5a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 10.5a3 3 0 01.45-1.59 4.124 4.124 0 00.45 6.84" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M18 10.5a3 3 0 00-.45-1.59 4.124 4.124 0 01-.45 6.84" />
+    </svg>
+);
+
+export const ArrowRightOnRectangleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 7.5l4.5 4.5-4.5 4.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M18 12H9" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 20.25h6A2.25 2.25 0 0012.75 18V6A2.25 2.25 0 0010.5 3.75h-6" />
+    </svg>
+);
+
+export const ArrowLeftOnRectangleIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 7.5L6 12l4.5 4.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12h-9" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 20.25h-6A2.25 2.25 0 0111.25 18V6A2.25 2.25 0 0113.5 3.75h6" />
+    </svg>
+);
+
+export const ArrowLeftIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 12h-15" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 6.75L4.5 12l5.25 5.25" />
+    </svg>
+);
+
+export const ArrowUpTrayIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 15.75V4.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 8.25L12 4.5l3.75 3.75" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75v1.5A2.25 2.25 0 006.75 19.5h10.5a2.25 2.25 0 002.25-2.25v-1.5" />
+    </svg>
+);
+
+export const CalendarPlusIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25" />
+        <rect x="3" y="6.75" width="18" height="13.5" rx="2.25" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 13.5h4.5M12 11.25v4.5" />
+    </svg>
+);
+
+export const CameraIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 7.5h2.318a1.5 1.5 0 001.342-.83l.68-1.36A1.5 1.5 0 0110.24 4.5h3.52a1.5 1.5 0 011.4.81l.68 1.36a1.5 1.5 0 001.34.83H19.5A1.5 1.5 0 0121 9v8.25A2.25 2.25 0 0118.75 19.5H5.25A2.25 2.25 0 013 17.25V9A1.5 1.5 0 014.5 7.5z" />
+        <circle cx="12" cy="12.75" r="3" />
+    </svg>
+);
+
+export const ClockIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <circle cx="12" cy="12" r="8.25" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5v4.5l2.25 2.25" />
+    </svg>
+);
+
+export const ListBulletIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <circle cx="5.25" cy="6.75" r="1.5" />
+        <circle cx="5.25" cy="12" r="1.5" />
+        <circle cx="5.25" cy="17.25" r="1.5" />
+        <path strokeLinecap="round" d="M9 6.75h10.5M9 12h10.5M9 17.25h10.5" />
+    </svg>
+);
+
+export const MiniSpinnerIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...props}>
+        <circle cx="12" cy="12" r="8" strokeOpacity={0.25} />
+        <path strokeLinecap="round" d="M20 12a8 8 0 00-8-8" />
+    </svg>
+);
+
+export const EnvelopeIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 6.75l8.954 5.373a1.5 1.5 0 001.592 0L21.75 6.75" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.5h16.5A1.5 1.5 0 0121.75 6v12a1.5 1.5 0 01-1.5 1.5H3.75A1.5 1.5 0 012.25 18V6a1.5 1.5 0 011.5-1.5z" />
+    </svg>
+);
+
+export const PencilIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 3.487a1.5 1.5 0 012.121 0l1.53 1.53a1.5 1.5 0 010 2.121l-9.19 9.19-3.712.742.742-3.712z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 20.25h13.5" />
+    </svg>
+);
+
+export const MenuIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+    </svg>
+);
+
+export const RefreshIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 4.5v5h5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 19.5v-5h-5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5.318 15.682a7.5 7.5 0 0111.036-10.364L18.75 7.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M18.682 8.318A7.5 7.5 0 017.646 18.682L5.25 16.5" />
+    </svg>
+);
+
+export const SearchIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <circle cx="10.5" cy="10.5" r="5.25" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16 16l4 4" />
+    </svg>
+);
+
+export const ServerIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <rect x="3.75" y="4.5" width="16.5" height="6" rx="1.5" />
+        <rect x="3.75" y="13.5" width="16.5" height="6" rx="1.5" />
+        <circle cx="7.5" cy="7.5" r="0.75" fill="currentColor" stroke="none" />
+        <circle cx="7.5" cy="16.5" r="0.75" fill="currentColor" stroke="none" />
+    </svg>
+);
+
+export const ShareIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <circle cx="7.5" cy="12" r="1.5" />
+        <circle cx="16.5" cy="6.75" r="1.5" />
+        <circle cx="16.5" cy="17.25" r="1.5" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8.85 11.25l6.3-3.15M8.85 12.75l6.3 3.15" />
+    </svg>
+);
+
+export const ShieldCheckIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 3.75l7.5 2.25v6.75c0 5.25-4.5 8.625-7.5 9.75-3-1.125-7.5-4.5-7.5-9.75V6z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 12.75l1.5 1.5 3-3" />
+    </svg>
+);
+
+export const SparklesIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11 3l1.5 4.5L17 9l-4.5 1.5L11 15l-1.5-4.5L5 9l4.5-1.5z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 5l.75 2.25L22 8l-2.25.75L19 11l-.75-2.25L16 8l2.25-.75z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l.75 2.25L8 18l-2.25.75L5 21l-.75-2.25L2 18l2.25-.75z" />
+    </svg>
+);
+
+export const MapIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 6.75L3 4.5v14.25l6.75 2.25 6.75-2.25L21 19.5V5.25l-4.5-1.5z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 6.75v14.25" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 4.5v14.25" />
+    </svg>
+);
+
+export const Squares2X2Icon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <rect x="4.5" y="4.5" width="7.5" height="7.5" rx="1.5" />
+        <rect x="12" y="4.5" width="7.5" height="7.5" rx="1.5" />
+        <rect x="4.5" y="12" width="7.5" height="7.5" rx="1.5" />
+        <rect x="12" y="12" width="7.5" height="7.5" rx="1.5" />
+    </svg>
+);
+
+export const StarIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke="none" {...props}>
+        <path d="M12 3.75l2.286 4.632 5.114.744-3.7 3.61.874 5.095L12 15.75l-4.574 2.381.874-5.095-3.7-3.61 5.114-.744z" />
+    </svg>
+);
+
+export const XMarkIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M6 18L18 6" />
+    </svg>
+);
+
+export const LockClosedIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 00-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+    </svg>
+);
+
+export const LockOpenIcon: React.FC<IconProps> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5V6.75a4.5 4.5 0 00-9 0v3.75m.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 10.5V6.75a1.5 1.5 0 113 0v3.75" />
+    </svg>
+);

--- a/the-scrum-book-nextjs/src/components/LeagueTableView.tsx
+++ b/the-scrum-book-nextjs/src/components/LeagueTableView.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import type { LeagueStanding, Venue } from '@/types';
+import { fetchLeagueTable } from '@/services/apiService';
+import { LoadingSpinner } from './LoadingSpinner';
+import { ErrorDisplay } from './ErrorDisplay';
+import { RefreshIcon, AlertTriangleIcon } from './Icons';
+import { TeamLogo } from './TeamLogo';
+import { ALL_VENUES, TEAM_BRANDING } from '@/services/mockData';
+import { getDistance } from '@/utils/geolocation';
+
+const FormIndicator: React.FC<{ form: string }> = ({ form }) => {
+    return (
+        <div className="flex gap-1">
+            {form.split('').slice(-5).map((result, index) => {
+                let color = 'bg-text-subtle/50';
+                if (result === 'W') color = 'bg-success';
+                if (result === 'L') color = 'bg-danger';
+                if (result === 'D') color = 'bg-warning';
+                return (
+                    <span key={index} className={`w-5 h-5 rounded-full flex items-center justify-center text-white text-[10px] font-bold ${color}`}>
+                        {result}
+                    </span>
+                );
+            })}
+        </div>
+    );
+};
+
+export const LeagueTableView: React.FC = () => {
+    const [table, setTable] = useState<LeagueStanding[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadTable = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const leagueTable = await fetchLeagueTable();
+            setTable(leagueTable);
+        } catch (err) {
+            setError("Could not load the league table. Please try again later.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadTable();
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64">
+                <LoadingSpinner />
+                <p className="mt-4 text-text-subtle">Loading League Table...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return <ErrorDisplay message={error} onRetry={loadTable} />;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-3 border-b border-border pb-4">
+                <h1 className="text-3xl font-bold text-text-strong">Betfred Super League Table</h1>
+                <button 
+                    onClick={loadTable}
+                    className="p-2 rounded-full text-text-subtle hover:bg-surface-alt transition-colors"
+                    aria-label="Refresh league table"
+                >
+                    <RefreshIcon className="w-6 h-6"/>
+                </button>
+            </div>
+            <div className="bg-surface rounded-md shadow-card overflow-hidden">
+                <div className="overflow-x-auto">
+                    <table className="w-full text-left text-text">
+                        <thead className="bg-surface-alt text-xs text-text-subtle uppercase">
+                            <tr>
+                                <th className="px-4 py-3 font-semibold text-center">Pos</th>
+                                <th className="px-4 py-3 font-semibold min-w-[200px]">Team</th>
+                                <th className="px-4 py-3 font-semibold text-center [font-variant-numeric:tabular-nums]">P</th>
+                                <th className="px-4 py-3 font-semibold text-center [font-variant-numeric:tabular-nums]">W</th>
+                                <th className="px-4 py-3 font-semibold text-center [font-variant-numeric:tabular-nums]">D</th>
+                                <th className="px-4 py-3 font-semibold text-center [font-variant-numeric:tabular-nums]">L</th>
+                                <th className="px-4 py-3 font-semibold text-center [font-variant-numeric:tabular-nums]">Pts</th>
+                                <th className="px-4 py-3 font-semibold">Form</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border">
+                            {table.map(standing => (
+                                <tr 
+                                    key={standing.teamId} 
+                                    className="hover:bg-surface-alt even:bg-surface-alt/50 transition-colors"
+                                    style={{ borderLeft: `4px solid ${TEAM_BRANDING[standing.teamId]?.bg || 'transparent'}` }}
+                                >
+                                    <td className="px-4 h-12 font-bold text-center text-text-strong">{standing.rank}</td>
+                                    <td className="px-4 h-12">
+                                        <div className="flex items-center gap-3">
+                                            <TeamLogo teamId={standing.teamId} teamName={standing.teamName} size="small" />
+                                            <span className="font-semibold text-text-strong">{standing.teamName}</span>
+                                        </div>
+                                    </td>
+                                    <td className="px-4 h-12 font-medium text-center [font-variant-numeric:tabular-nums]">{standing.played}</td>
+                                    <td className="px-4 h-12 font-medium text-center text-success [font-variant-numeric:tabular-nums]">{standing.wins}</td>
+                                    <td className="px-4 h-12 font-medium text-center [font-variant-numeric:tabular-nums]">{standing.draws}</td>
+                                    <td className="px-4 h-12 font-medium text-center text-danger [font-variant-numeric:tabular-nums]">{standing.losses}</td>
+                                    <td className="px-4 h-12 font-bold text-center text-primary [font-variant-numeric:tabular-nums]">{standing.points}</td>
+                                    <td className="px-4 h-12">
+                                        <FormIndicator form={standing.form} />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+// --- Grounds View Component ---
+
+type LocationState = {
+    lat: number;
+    lon: number;
+} | null;
+
+type GeolocationError = {
+    code: number;
+    message: string;
+} | null;
+
+interface SortedVenue extends Venue {
+    distance: number;
+}
+
+export const GroundsView: React.FC = () => {
+    const [location, setLocation] = useState<LocationState>(null);
+    const [sortedVenues, setSortedVenues] = useState<SortedVenue[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<GeolocationError>(null);
+
+    const getLocation = () => {
+        setLoading(true);
+        setError(null);
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const { latitude, longitude } = position.coords;
+                setLocation({ lat: latitude, lon: longitude });
+            },
+            (err) => {
+                setError({ code: err.code, message: err.message });
+                setLoading(false);
+            },
+            { timeout: 10000 }
+        );
+    };
+
+    useEffect(() => {
+        getLocation();
+    }, []);
+
+    useEffect(() => {
+        if (location) {
+            const venuesWithDistance = ALL_VENUES.map(venue => ({
+                ...venue,
+                distance: getDistance(location.lat, location.lon, venue.lat, venue.lon),
+            }));
+            venuesWithDistance.sort((a, b) => a.distance - b.distance);
+            setSortedVenues(venuesWithDistance);
+            setLoading(false);
+        }
+    }, [location]);
+
+    if (loading) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64">
+                <LoadingSpinner />
+                <p className="mt-4 text-text-subtle text-center">Getting your location to find nearest grounds...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-surface p-8 rounded-md text-center flex flex-col items-center shadow-card">
+                <AlertTriangleIcon className="w-12 h-12 text-danger mb-4" />
+                <h2 className="text-xl font-bold text-text-strong mb-2">Location Error</h2>
+                <p className="text-text-subtle mb-6 max-w-md">
+                    {error.code === 1 
+                        ? "You've denied location access. Please enable it in your browser settings to use this feature." 
+                        : "Could not determine your location. Please check your connection and try again."}
+                </p>
+                <button
+                    onClick={getLocation}
+                    className="bg-primary text-white font-semibold py-2 px-6 rounded-md hover:bg-primary/90 transition-colors duration-200"
+                >
+                    Try Again
+                </button>
+            </div>
+        );
+    }
+    
+    return (
+        <div className="space-y-6">
+            <div className="border-b border-border pb-4">
+                <h1 className="text-3xl font-bold text-text-strong">Super League Grounds</h1>
+                <p className="text-text-subtle mt-1">Stadiums sorted by distance from your current location.</p>
+            </div>
+            <div className="bg-surface rounded-md shadow-card overflow-hidden">
+                <ul className="divide-y divide-border">
+                    {sortedVenues.map((venue, index) => (
+                        <li key={venue.name} className="p-4 flex items-center justify-between hover:bg-surface-alt transition-colors duration-200">
+                            <div className="flex items-center gap-4">
+                                <span className="font-bold text-lg text-primary w-8 text-center [font-variant-numeric:tabular-nums]">{index + 1}</span>
+                                <div>
+                                    <p className="font-bold text-text-strong">{venue.name}</p>
+                                    <p className="text-sm text-text-subtle">{venue.team}</p>
+                                </div>
+                            </div>
+                            <div className="text-right flex-shrink-0 ml-4">
+                                <p className="font-bold text-text-strong text-lg [font-variant-numeric:tabular-nums]">{venue.distance.toFixed(1)} mi</p>
+                                <p className="text-sm text-text-subtle">away</p>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/LoadingSpinner.tsx
+++ b/the-scrum-book-nextjs/src/components/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+
+import React from 'react';
+
+export const LoadingSpinner: React.FC = () => {
+  return (
+    <div className="w-12 h-12 border-4 border-dashed rounded-full animate-spin border-primary"></div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/LoginPromptView.tsx
+++ b/the-scrum-book-nextjs/src/components/LoginPromptView.tsx
@@ -1,0 +1,525 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  LogoIcon,
+  UserCircleIcon,
+  EnvelopeIcon,
+  LockClosedIcon,
+  MiniSpinnerIcon,
+} from './Icons';
+
+type AuthMode = 'login' | 'signup' | 'forgot';
+
+interface LoginPromptViewProps {
+  theme: 'light' | 'dark';
+  onLogin?: () => Promise<void>;
+  onEmailLogin: (identifier: string, password: string) => Promise<void>;
+  onSignup: (input: { name: string; email: string; password: string }) => Promise<void>;
+  onPasswordReset: (identifier: string) => Promise<void>;
+}
+
+type ActiveRequest = AuthMode | 'google' | null;
+
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+const getFeedbackClasses = (mode: AuthMode, type: 'success' | 'error') => {
+  const palette = {
+    login: {
+      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
+      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+    },
+    signup: {
+      success: 'bg-emerald-50 text-emerald-600 border-emerald-200',
+      error: 'bg-rose-50 text-rose-600 border-rose-200',
+    },
+    forgot: {
+      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
+      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+    },
+  } as const;
+
+  return palette[mode][type];
+};
+
+export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
+  theme,
+  onLogin,
+  onEmailLogin,
+  onSignup,
+  onPasswordReset,
+}) => {
+  const [mode, setMode] = useState<AuthMode>('login');
+  const [activeRequest, setActiveRequest] = useState<ActiveRequest>(null);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const [loginForm, setLoginForm] = useState({ identifier: '', password: '' });
+  const [signupForm, setSignupForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    acceptsTerms: false,
+  });
+  const [forgotForm, setForgotForm] = useState({ email: '' });
+
+  const isGoogleConfigured = useMemo(() => Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID), []);
+  const canUseGoogle = Boolean(onLogin) && isGoogleConfigured;
+
+  useEffect(() => {
+    setFeedback(null);
+  }, [mode]);
+
+  const setRequest = (request: ActiveRequest) => {
+    setActiveRequest(request);
+    if (request) {
+      setFeedback(null);
+    }
+  };
+
+  const resetRequest = () => setActiveRequest(null);
+
+  const handleCredentialLogin = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
+
+    if (!loginForm.identifier.trim() || !loginForm.password.trim()) {
+      setFeedback({ type: 'error', message: 'Enter your email (or phone) and password to continue.' });
+      return;
+    }
+
+    setRequest('login');
+    try {
+      await onEmailLogin(loginForm.identifier, loginForm.password);
+      setFeedback({ type: 'success', message: 'Welcome back! Loading your profile…' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'Unable to sign in with those details. Please try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleSignup = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
+
+    if (!signupForm.acceptsTerms) {
+      setFeedback({ type: 'error', message: 'Please agree to the Terms & Privacy to continue.' });
+      return;
+    }
+
+    if (!signupForm.name.trim()) {
+      setFeedback({ type: 'error', message: 'Enter your full name so we know what to call you.' });
+      return;
+    }
+
+    if (!signupForm.email.trim()) {
+      setFeedback({ type: 'error', message: 'Enter an email address to create your account.' });
+      return;
+    }
+
+    if (signupForm.password.length < 6) {
+      setFeedback({ type: 'error', message: 'Passwords need to be at least 6 characters long.' });
+      return;
+    }
+
+    if (signupForm.password !== signupForm.confirmPassword) {
+      setFeedback({ type: 'error', message: 'Passwords do not match. Please re-type them.' });
+      return;
+    }
+
+    setRequest('signup');
+    try {
+      await onSignup({
+        name: signupForm.name,
+        email: signupForm.email,
+        password: signupForm.password,
+      });
+      setFeedback({ type: 'success', message: 'Account created! Setting up your experience…' });
+      setSignupForm({ name: '', email: '', password: '', confirmPassword: '', acceptsTerms: false });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'We could not create your account just yet. Try again shortly.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleForgotPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (activeRequest) return;
+
+    if (!forgotForm.email.trim()) {
+      setFeedback({ type: 'error', message: 'Enter the email linked to your account.' });
+      return;
+    }
+
+    setRequest('forgot');
+    try {
+      await onPasswordReset(forgotForm.email);
+      setFeedback({
+        type: 'success',
+        message: 'Check your inbox for reset instructions (they may be in spam).',
+      });
+      setForgotForm({ email: '' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'We could not find that email. Double check and try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    if (!canUseGoogle || activeRequest) return;
+
+    setRequest('google');
+    try {
+      await onLogin?.();
+      setFeedback({ type: 'success', message: 'Connecting you with Google…' });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: getErrorMessage(error, 'Google sign-in failed. Please try again.'),
+      });
+    } finally {
+      resetRequest();
+    }
+  };
+
+  const renderFeedback = () => {
+    if (!feedback) {
+      return null;
+    }
+    return (
+      <div
+        className={`mt-5 rounded-full border px-5 py-2 text-sm font-medium tracking-wide ${getFeedbackClasses(
+          mode,
+          feedback.type
+        )}`}
+      >
+        {feedback.message}
+      </div>
+    );
+  };
+
+  const busy = (request: ActiveRequest) => activeRequest === request;
+
+  const renderLoginCard = () => (
+    <div className="mx-auto w-full max-w-[420px]">
+      <div className="relative overflow-hidden rounded-[36px] bg-[#031a29] px-8 pb-12 pt-14 text-white shadow-[0px_25px_60px_rgba(3,26,41,0.55)]">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute -top-24 -right-20 h-64 w-64 rounded-full bg-[#103852] opacity-50 blur-3xl" />
+          <LogoIcon
+            className="absolute -top-28 left-1/2 h-60 w-60 -translate-x-1/2 opacity-[0.08]"
+            theme="dark"
+            aria-hidden
+          />
+        </div>
+
+        <div className="relative flex flex-col items-center text-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0px_15px_35px_rgba(3,19,31,0.45)]">
+            <LogoIcon className="h-12 w-12 drop-shadow" theme={theme} />
+          </div>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
+          <p className="mt-3 max-w-xs text-sm text-white/60">
+            Sign in to manage your matchdays, track your stats, and stay connected with the rugby league community.
+          </p>
+        </div>
+
+        <form className="relative mt-8 space-y-5" onSubmit={handleCredentialLogin}>
+          <div>
+            <label className="sr-only" htmlFor="auth-identifier">
+              Email or phone number
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-5 py-3 text-base transition focus-within:border-white/60 focus-within:bg-white/10">
+              <EnvelopeIcon className="h-5 w-5 text-white/70" />
+              <input
+                id="auth-identifier"
+                type="text"
+                autoComplete="username"
+                placeholder="Email or Phone"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={loginForm.identifier}
+                onChange={(event) => setLoginForm((prev) => ({ ...prev, identifier: event.target.value }))}
+                disabled={busy('login')}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="sr-only" htmlFor="auth-password">
+              Password
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-5 py-3 text-base transition focus-within:border-white/60 focus-within:bg-white/10">
+              <LockClosedIcon className="h-5 w-5 text-white/70" />
+              <input
+                id="auth-password"
+                type="password"
+                autoComplete="current-password"
+                placeholder="Password"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={loginForm.password}
+                onChange={(event) => setLoginForm((prev) => ({ ...prev, password: event.target.value }))}
+                disabled={busy('login')}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between text-sm font-medium text-white/70">
+            <button
+              type="button"
+              className="underline decoration-white/40 decoration-dotted underline-offset-4 hover:text-white"
+              onClick={() => setMode('forgot')}
+            >
+              Forgot Password?
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#032130] shadow-[0px_12px_35px_rgba(3,19,31,0.45)] transition hover:bg-white/90 disabled:opacity-70"
+            disabled={busy('login')}
+          >
+            {busy('login') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#032130]" />
+                Logging in…
+              </>
+            ) : (
+              'Login'
+            )}
+          </button>
+
+          <div className="flex items-center gap-4 text-white/40">
+            <span className="h-px flex-1 bg-white/20" />
+            <span className="text-xs uppercase tracking-[0.5em]">or</span>
+            <span className="h-px flex-1 bg-white/20" />
+          </div>
+
+          <button
+            type="button"
+            className="w-full rounded-full border border-white/20 bg-transparent py-3 text-base font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+            onClick={() => setMode('signup')}
+          >
+            Create an account
+          </button>
+
+          {canUseGoogle ? (
+            <button
+              type="button"
+              className="w-full rounded-full border border-white/20 bg-transparent py-3 text-base font-semibold text-white transition hover:border-white/40 hover:bg-white/5"
+              onClick={handleGoogleLogin}
+              disabled={busy('google')}
+            >
+              {busy('google') ? 'Connecting to Google…' : 'Continue with Google'}
+            </button>
+          ) : null}
+
+          {!canUseGoogle && onLogin && !isGoogleConfigured ? (
+            <p className="text-center text-xs text-white/50">
+              Google Sign-In isn&apos;t configured. Set <code className="rounded bg-black/30 px-1">VITE_GOOGLE_CLIENT_ID</code> to enable it.
+            </p>
+          ) : null}
+
+          {renderFeedback()}
+        </form>
+      </div>
+    </div>
+  );
+
+  const renderSignupCard = () => (
+    <div className="mx-auto w-full max-w-[480px] overflow-hidden rounded-[36px] bg-white shadow-[0px_25px_60px_rgba(3,26,41,0.35)]">
+      <div className="relative bg-[#031d2c] px-10 pb-12 pt-16 text-white">
+        <LogoIcon className="absolute -right-14 -top-14 h-40 w-40 opacity-[0.08]" theme="dark" aria-hidden />
+        <p className="text-lg font-semibold uppercase tracking-[0.35em] text-white/60">Let&apos;s</p>
+        <h2 className="mt-3 text-4xl font-heading leading-[1.15]">
+          Create
+          <br />
+          Your Account
+        </h2>
+        <p className="mt-4 max-w-sm text-sm text-white/70">
+          Join the community, track your matchdays, and unlock exclusive rugby league stats.
+        </p>
+      </div>
+
+      <form className="bg-white px-10 py-10" onSubmit={handleSignup}>
+        <div className="space-y-5">
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <UserCircleIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="text"
+              placeholder="Full Name"
+              autoComplete="name"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.name}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, name: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <EnvelopeIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="email"
+              placeholder="Email Address"
+              autoComplete="email"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.email}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, email: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="password"
+              placeholder="Password"
+              autoComplete="new-password"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.password}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, password: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
+            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+            <input
+              type="password"
+              placeholder="Retype Password"
+              autoComplete="new-password"
+              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              value={signupForm.confirmPassword}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, confirmPassword: event.target.value }))}
+              disabled={busy('signup')}
+            />
+          </div>
+
+          <label className="flex items-center gap-3 text-sm text-[#0B2A2F]/70">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border border-[#0B2A2F]/30 text-[#0B2A2F] focus:ring-[#0B2A2F]"
+              checked={signupForm.acceptsTerms}
+              onChange={(event) => setSignupForm((prev) => ({ ...prev, acceptsTerms: event.target.checked }))}
+              disabled={busy('signup')}
+            />
+            <span>
+              I agree to the <span className="font-semibold text-[#0B2A2F]">Terms &amp; Privacy</span>
+            </span>
+          </label>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-[#d9e4ec] py-3 text-base font-semibold text-[#0B2A2F] transition hover:bg-[#c8d7e2] disabled:opacity-60"
+            disabled={busy('signup')}
+          >
+            {busy('signup') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#0B2A2F]" />
+                Signing you up…
+              </>
+            ) : (
+              'Sign Up'
+            )}
+          </button>
+
+          {renderFeedback()}
+
+          <p className="mt-6 text-center text-sm text-[#0B2A2F]/70">
+            Have an account?
+            <button
+              type="button"
+              className="ml-1 font-semibold text-[#0B2A2F] underline decoration-dotted underline-offset-4"
+              onClick={() => setMode('login')}
+            >
+              Sign In
+            </button>
+          </p>
+        </div>
+      </form>
+    </div>
+  );
+
+  const renderForgotCard = () => (
+    <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-[36px] bg-white text-[#0B2A2F] shadow-[0px_25px_60px_rgba(3,26,41,0.35)]">
+      <div className="px-10 pb-8 pt-12 text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[#0B2A2F]/10 text-[#0B2A2F]">
+          <LockClosedIcon className="h-7 w-7" />
+        </div>
+        <h2 className="text-3xl font-heading font-semibold text-[#133347]">Forgot Password?</h2>
+        <p className="mt-3 text-sm text-[#375566]">No worries, we&apos;ll send you reset instructions.</p>
+      </div>
+
+      <div className="relative bg-[#031d2c] px-10 pb-10 pt-10 text-white">
+        <LogoIcon className="pointer-events-none absolute -bottom-10 right-8 h-28 w-28 opacity-[0.08]" theme="dark" aria-hidden />
+        <form className="space-y-6" onSubmit={handleForgotPassword}>
+          <div>
+            <label className="sr-only" htmlFor="forgot-email">
+              Email address
+            </label>
+            <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-5 py-3 transition focus-within:border-white focus-within:bg-white/20">
+              <EnvelopeIcon className="h-5 w-5 text-white/80" />
+              <input
+                id="forgot-email"
+                type="email"
+                placeholder="Enter your Email"
+                autoComplete="email"
+                className="w-full bg-transparent text-base text-white placeholder:text-white/60 focus:outline-none"
+                value={forgotForm.email}
+                onChange={(event) => setForgotForm({ email: event.target.value })}
+                disabled={busy('forgot')}
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#031d2c] shadow-[0px_10px_40px_rgba(0,0,0,0.35)] transition hover:bg-white/95 disabled:opacity-70"
+            disabled={busy('forgot')}
+          >
+            {busy('forgot') ? (
+              <>
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#031d2c]" />
+                Sending reset link…
+              </>
+            ) : (
+              'Reset Password'
+            )}
+          </button>
+
+          {renderFeedback()}
+
+          <button
+            type="button"
+            className="mx-auto block text-sm font-semibold text-white/80 underline decoration-dotted underline-offset-4 hover:text-white"
+            onClick={() => setMode('login')}
+          >
+            Back to Login
+          </button>
+        </form>
+        <div className="mt-8 flex justify-center">
+          <LogoIcon className="h-8 w-8 opacity-80" theme="dark" />
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col items-center justify-center py-10 sm:py-12">
+      {mode === 'login' ? renderLoginCard() : null}
+      {mode === 'signup' ? renderSignupCard() : null}
+      {mode === 'forgot' ? renderForgotCard() : null}
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MatchList.tsx
+++ b/the-scrum-book-nextjs/src/components/MatchList.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import type { Match } from '@/types';
+import { MatchListItem } from './MatchListItem';
+import { RefreshIcon, SearchIcon } from './Icons';
+
+interface MatchListProps {
+  matches: Match[];
+  attendedMatchIds: string[];
+  onAttend: (match: Match) => void;
+  onRefresh: () => void;
+}
+
+export const MatchList: React.FC<MatchListProps> = ({ matches, attendedMatchIds, onAttend, onRefresh }) => {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const { upcomingMatches, filteredMatches } = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const sevenDaysFromNow = new Date(today);
+    sevenDaysFromNow.setDate(today.getDate() + 7);
+
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    const upcoming = matches
+      .filter(match => {
+        const matchDate = new Date(match.startTime);
+        return matchDate >= today && matchDate < sevenDaysFromNow;
+      })
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+
+    const filtered = normalizedQuery
+      ? upcoming.filter(match => {
+          const home = match.homeTeam?.name?.toLowerCase() ?? '';
+          const away = match.awayTeam?.name?.toLowerCase() ?? '';
+          return home.includes(normalizedQuery) || away.includes(normalizedQuery);
+        })
+      : upcoming;
+
+    return { upcomingMatches: upcoming, filteredMatches: filtered };
+  }, [matches, searchQuery]);
+
+  const showNoMatchesMessage = upcomingMatches.length === 0;
+  const showNoResultsMessage = !showNoMatchesMessage && filteredMatches.length === 0;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 border-b border-border pb-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold text-text-strong">Matches in the Next 7 Days</h1>
+          <button
+            onClick={onRefresh}
+            className="rounded-full p-2 text-text-subtle transition-colors hover:bg-surface-alt"
+            aria-label="Refresh matches"
+          >
+            <RefreshIcon className="h-6 w-6" />
+          </button>
+        </div>
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <SearchIcon className="h-5 w-5 text-text-subtle" />
+          </div>
+          <input
+            type="text"
+            placeholder="Filter by team name..."
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+            className="w-full rounded-md border border-border bg-surface py-2 pl-10 pr-4 text-text placeholder:text-text-subtle focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary md:w-64"
+          />
+        </div>
+      </div>
+
+      {showNoMatchesMessage && (
+        <div className="rounded-md bg-surface py-20 text-center text-text">
+          <h2 className="text-2xl font-bold text-text-strong">No Matches Scheduled</h2>
+          <p className="mt-2 text-text-subtle">There are no matches scheduled in the next 7 days.</p>
+        </div>
+      )}
+
+      {showNoResultsMessage && (
+        <div className="rounded-md bg-surface py-20 text-center text-text">
+          <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
+          <p className="mt-2 text-text-subtle">
+            No upcoming matches found for "{searchQuery}". Try a different search.
+          </p>
+        </div>
+      )}
+
+      {!showNoMatchesMessage && !showNoResultsMessage && (
+        <div className="space-y-4">
+          {filteredMatches.map(match => (
+            <MatchListItem
+              key={match.id}
+              match={match}
+              isAttended={attendedMatchIds.includes(match.id)}
+              onAttend={onAttend}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MatchListItem.tsx
+++ b/the-scrum-book-nextjs/src/components/MatchListItem.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import React, { useState } from 'react';
+import type { Match } from '@/types';
+import {
+  CalendarPlusIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  LocationMarkerIcon,
+  MiniSpinnerIcon,
+  PlusCircleIcon,
+  ShareIcon,
+} from './Icons';
+import { TeamLogo } from './TeamLogo';
+import { ALL_VENUES } from '@/services/mockData';
+import { getDistance } from '@/utils/geolocation';
+import { formatDateUK } from '@/utils/date';
+import { attemptShare, getAppShareUrl, type ShareOutcome } from '@/utils/share';
+
+interface MatchListItemProps {
+  match: Match;
+  isAttended: boolean;
+  onAttend: (match: Match) => void;
+  distance?: number;
+}
+
+const CHECKIN_RADIUS_MILES = 1.0;
+const CHECKIN_RESET_DELAY = 3000;
+
+const isToday = (dateString: string): boolean => {
+  const today = new Date();
+  const someDate = new Date(dateString);
+  return (
+    someDate.getDate() === today.getDate() &&
+    someDate.getMonth() === today.getMonth() &&
+    someDate.getFullYear() === today.getFullYear()
+  );
+};
+
+const formatCalendarDate = (date: Date) => date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+
+export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended, onAttend, distance }) => {
+  const [checkinState, setCheckinState] = useState<{
+    status: 'idle' | 'checking' | 'error_distance' | 'error_location';
+    message: string;
+  }>({ status: 'idle', message: '' });
+  const [shareFeedback, setShareFeedback] = useState<'idle' | ShareOutcome>('idle');
+
+  const isFullTime = match.status === 'FULL-TIME';
+  const isScheduled = match.status === 'SCHEDULED';
+  const matchIsToday = isToday(match.startTime);
+  const matchTime = new Date(match.startTime).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+  const resetCheckinState = () => {
+    setTimeout(() => setCheckinState({ status: 'idle', message: '' }), CHECKIN_RESET_DELAY);
+  };
+
+  const handleMarkAsAttended = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    onAttend(match);
+  };
+
+  const handleAddToCalendar = (event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    const startDate = new Date(match.startTime);
+    const endDate = new Date(startDate.getTime() + 105 * 60 * 1000);
+    const summary = `${match.homeTeam.name} vs ${match.awayTeam.name}`;
+    const details = `Betfred Super League: ${summary}`;
+
+    const calendarUrl = new URL('https://calendar.google.com/calendar/render');
+    calendarUrl.searchParams.set('action', 'TEMPLATE');
+    calendarUrl.searchParams.set('text', summary);
+    calendarUrl.searchParams.set('dates', `${formatCalendarDate(startDate)}/${formatCalendarDate(endDate)}`);
+    calendarUrl.searchParams.set('details', details);
+    calendarUrl.searchParams.set('location', match.venue);
+    calendarUrl.searchParams.set('sf', 'true');
+    calendarUrl.searchParams.set('output', 'xml');
+
+    const newWindow = window.open(calendarUrl.toString(), '_blank');
+    if (!newWindow) {
+      window.location.href = calendarUrl.toString();
+    }
+  };
+
+  const handleCheckIn = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setCheckinState({ status: 'checking', message: 'Checking location...' });
+
+    const handleLocationError = (message: string, status: 'error_distance' | 'error_location') => {
+      setCheckinState({ status, message });
+      resetCheckinState();
+    };
+
+    if (!navigator.geolocation) {
+      handleLocationError('Location not supported', 'error_location');
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const { latitude, longitude } = position.coords;
+        const stadium = ALL_VENUES.find(venue => venue.name === match.venue);
+
+        if (!stadium) {
+          handleLocationError('Stadium location unknown', 'error_location');
+          return;
+        }
+
+        const userDistance = getDistance(latitude, longitude, stadium.lat, stadium.lon);
+
+        if (userDistance <= CHECKIN_RADIUS_MILES) {
+          onAttend(match);
+          setCheckinState({ status: 'idle', message: '' });
+        } else {
+          handleLocationError(`Too far away (${userDistance.toFixed(1)} mi)`, 'error_distance');
+        }
+      },
+      error => {
+        console.error('Geolocation error:', error);
+        handleLocationError('Location unavailable', 'error_location');
+      },
+      { timeout: 10000, enableHighAccuracy: true },
+    );
+  };
+
+  const handleShareCheckIn = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    const shareText = `Just checked in at ${match.homeTeam?.name ?? 'Home Team'} vs ${match.awayTeam?.name ?? 'Away Team'} at ${match.venue}.`;
+    const shareUrl = getAppShareUrl();
+
+    const outcome = await attemptShare({
+      title: 'Matchday Check-in',
+      text: shareText,
+      url: shareUrl,
+      clipboardFallbackText: `${shareText} Track every matchday with The Scrum Book: ${shareUrl}`,
+    });
+
+    setShareFeedback(outcome);
+    setTimeout(() => setShareFeedback('idle'), 2500);
+  };
+
+  const renderShareFeedbackMessage = () => {
+    if (shareFeedback === 'copied') {
+      return 'Link copied!';
+    }
+    if (shareFeedback === 'shared') {
+      return 'Share sheet opened';
+    }
+    if (shareFeedback === 'failed') {
+      return 'Sharing unavailable';
+    }
+    return '';
+  };
+
+  const renderAttendButton = () => {
+    if (isAttended) {
+      const feedbackMessage = renderShareFeedbackMessage();
+
+      return (
+        <div className="flex flex-col items-stretch gap-1">
+          <div className="flex items-center gap-2">
+            <button className="flex cursor-default items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-semibold text-white" disabled>
+              <CheckCircleIcon className="h-4 w-4" />
+              <span>Attended</span>
+            </button>
+            <button
+              onClick={handleShareCheckIn}
+              className="flex items-center gap-1.5 rounded-md border border-primary px-3 py-1.5 text-xs font-semibold text-primary transition-colors duration-200 hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt"
+              aria-label="Share check-in"
+            >
+              <ShareIcon className="h-4 w-4" />
+              <span className="hidden sm:inline">Share check-in</span>
+              <span className="sm:hidden">Share</span>
+            </button>
+          </div>
+          {feedbackMessage && (
+            <span className="text-[11px] font-semibold text-text-subtle" role="status" aria-live="polite">
+              {feedbackMessage}
+            </span>
+          )}
+        </div>
+      );
+    }
+
+    if (matchIsToday && !isFullTime) {
+      const isChecking = checkinState.status === 'checking';
+      const isError = checkinState.status.startsWith('error');
+
+      let buttonClass = 'bg-info text-white hover:bg-info/90';
+      if (isError) buttonClass = 'bg-danger text-white';
+      if (isChecking) buttonClass = 'bg-info/80 text-white cursor-wait';
+
+      return (
+        <button
+          onClick={handleCheckIn}
+          disabled={isChecking}
+          className={`flex w-32 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt ${buttonClass}`}
+        >
+          {isChecking && <MiniSpinnerIcon className="h-4 w-4" />}
+          {!isChecking && <LocationMarkerIcon className="h-4 w-4" />}
+          <span>{checkinState.status !== 'idle' ? checkinState.message : 'Check In'}</span>
+        </button>
+      );
+    }
+
+    return (
+      <button
+        onClick={handleMarkAsAttended}
+        className="flex items-center gap-1.5 rounded-md border border-secondary px-3 py-1.5 text-xs font-semibold text-secondary transition-colors duration-200 hover:bg-secondary/10 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt"
+      >
+        <PlusCircleIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">I was there</span>
+        <span className="sm:hidden">Attend</span>
+      </button>
+    );
+  };
+
+  return (
+    <article className="overflow-hidden rounded-md bg-surface shadow-card transition-shadow duration-300 hover:shadow-lg">
+      <div className="grid items-center gap-3 p-4 [grid-template-columns:1fr_auto_1fr]">
+        <div className="flex min-w-0 items-center gap-3">
+          <TeamLogo teamId={match.homeTeam?.id} teamName={match.homeTeam?.name ?? 'Home'} size="medium" />
+          <span className="truncate text-sm font-semibold text-text-strong md:text-base">{match.homeTeam?.name ?? 'Home Team'}</span>
+        </div>
+
+        <div className="text-center">
+          <div className="flex min-h-[40px] items-center justify-center gap-2 text-4xl font-extrabold text-text-strong [font-variant-numeric:tabular-nums]">
+            {isFullTime ? (
+              <>
+                <span>{match.scores.home}</span>
+                <span>-</span>
+                <span>{match.scores.away}</span>
+              </>
+            ) : (
+              <span className="text-2xl font-semibold tracking-wider text-text-subtle">VS</span>
+            )}
+          </div>
+          <div
+            className={`mt-1 inline-flex items-center gap-2 rounded-md px-2 py-1 text-xs font-semibold ${
+              isFullTime ? 'bg-accent text-text-strong' : 'bg-surface-alt text-text-subtle'
+            }`}
+          >
+            {isFullTime ? 'FT' : matchTime}
+          </div>
+        </div>
+
+        <div className="flex min-w-0 items-center justify-end gap-3">
+          <span className="truncate text-right text-sm font-semibold text-text-strong md:text-base">{match.awayTeam?.name ?? 'Away Team'}</span>
+          <TeamLogo teamId={match.awayTeam?.id} teamName={match.awayTeam?.name ?? 'Away'} size="medium" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-border bg-surface-alt px-4 py-3 text-sm text-text-subtle sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          <div className="flex items-center gap-1.5">
+            <LocationMarkerIcon className="h-4 w-4" />
+            <span>{match.venue}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ClockIcon className="h-4 w-4" />
+            <span>{formatDateUK(match.startTime)}</span>
+          </div>
+          {distance !== undefined && (
+            <div className="flex items-center gap-1.5 rounded-full bg-surface px-2.5 py-1 text-xs font-semibold text-text-strong shadow-sm ring-1 ring-border/60">
+              <span className="tracking-tight">{distance.toFixed(1)} mi away</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 self-end sm:self-auto">
+          {isScheduled && (
+            <button
+              onClick={handleAddToCalendar}
+              className="flex items-center gap-1.5 rounded-md bg-info px-3 py-1.5 text-xs font-semibold text-white transition-colors duration-200 hover:bg-info/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1 focus:ring-offset-surface-alt"
+              aria-label="Add match to calendar"
+            >
+              <CalendarPlusIcon className="h-4 w-4" />
+              <span className="hidden sm:inline">Add to Calendar</span>
+              <span className="sm:hidden">Calendar</span>
+            </button>
+          )}
+          {renderAttendButton()}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MatchdayView.tsx
+++ b/the-scrum-book-nextjs/src/components/MatchdayView.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import type { Match } from '@/types';
+import { MatchListItem } from './MatchListItem';
+import { formatDateUK } from '@/utils/date';
+
+interface MatchdayViewProps {
+  matches: Match[];
+  attendedMatchIds: string[];
+  onAttend: (match: Match) => void;
+}
+
+type ActiveTab = 'fixtures' | 'results';
+
+type TabButtonProps = {
+  tab: ActiveTab;
+  label: string;
+  isActive: boolean;
+  onClick: (tab: ActiveTab) => void;
+};
+
+const TabButton: React.FC<TabButtonProps> = ({ tab, label, isActive, onClick }) => (
+  <button
+    onClick={() => onClick(tab)}
+    className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary/50 ${
+      isActive ? 'bg-primary text-white shadow-sm' : 'bg-transparent text-text-subtle hover:bg-surface hover:text-text'
+    }`}
+  >
+    {label}
+  </button>
+);
+
+export const MatchdayView: React.FC<MatchdayViewProps> = ({ matches, attendedMatchIds, onAttend }) => {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('results');
+
+  const { fixtures, results } = useMemo(() => {
+    const fixturesList = matches
+      .filter(match => match.status === 'SCHEDULED')
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+
+    const resultsList = matches
+      .filter(match => match.status === 'FULL-TIME')
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+
+    return { fixtures: fixturesList, results: resultsList };
+  }, [matches]);
+
+  const matchesToDisplay = activeTab === 'fixtures' ? fixtures : results;
+
+  const groupedMatches = useMemo(() => {
+    return matchesToDisplay.reduce<Record<string, Match[]>>((accumulator, match) => {
+      const dateKey = new Date(match.startTime).toDateString();
+      if (!accumulator[dateKey]) {
+        accumulator[dateKey] = [];
+      }
+      accumulator[dateKey].push(match);
+      return accumulator;
+    }, {});
+  }, [matchesToDisplay]);
+
+  const sortedDateKeys = Object.keys(groupedMatches);
+
+  const renderMatchList = () => {
+    if (sortedDateKeys.length === 0) {
+      return (
+        <div className="rounded-md bg-surface py-20 text-center">
+          <h2 className="text-2xl font-bold text-text-strong">
+            {activeTab === 'fixtures' ? 'No Upcoming Fixtures' : 'No Past Results'}
+          </h2>
+          <p className="mt-2 text-text-subtle">
+            {activeTab === 'fixtures'
+              ? 'Check back later for more scheduled matches.'
+              : 'There are no results to display for this season.'}
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-8">
+        {sortedDateKeys.map(dateKey => (
+          <div key={dateKey}>
+            <h2 className="mb-4 border-b-2 border-primary pb-2 text-xl font-bold text-text-strong">
+              {formatDateUK(dateKey)}
+            </h2>
+            <div className="space-y-4">
+              {groupedMatches[dateKey].map(match => (
+                <MatchListItem
+                  key={match.id}
+                  match={match}
+                  isAttended={attendedMatchIds.includes(match.id)}
+                  onAttend={onAttend}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="border-b border-border pb-4">
+        <h1 className="text-3xl font-bold text-text-strong">Fixtures &amp; Results</h1>
+        <p className="mt-1 text-text-subtle">View upcoming matches or past results for the season.</p>
+      </div>
+
+      <div className="flex w-fit items-center gap-2 rounded-xl bg-surface-alt p-1">
+        <TabButton tab="results" label="Results" isActive={activeTab === 'results'} onClick={setActiveTab} />
+        <TabButton tab="fixtures" label="Fixtures" isActive={activeTab === 'fixtures'} onClick={setActiveTab} />
+      </div>
+
+      {renderMatchList()}
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MobileBottomBar.tsx
+++ b/the-scrum-book-nextjs/src/components/MobileBottomBar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import type { View } from '@/types';
+import { mainNavigationItems } from './navigationItems';
+
+interface MobileBottomBarProps {
+  currentView: View;
+  setView: (view: View) => void;
+}
+
+export const MobileBottomBar: React.FC<MobileBottomBarProps> = ({ currentView, setView }) => {
+  return (
+    <nav className="md:hidden fixed inset-x-0 bottom-0 z-20 border-t border-border/70 bg-surface/95 backdrop-blur">
+      <div className="mx-auto w-full max-w-2xl px-1.5 pb-[calc(env(safe-area-inset-bottom)+6px)] pt-1">
+        {/* Changed from a grid to a flexbox for a single row layout */}
+        <div className="flex items-center justify-around">
+          {mainNavigationItems.map(({ label, view, icon: Icon }) => {
+            const isActive = currentView === view;
+            return (
+              <button
+                key={view}
+                type="button"
+                onClick={() => setView(view)}
+                // Updated styles for an icon-only button
+                className={`flex h-12 w-16 items-center justify-center rounded-lg transition-colors ${
+                  isActive
+                    ? 'bg-primary/20 text-primary'
+                    : 'text-text-subtle hover:text-text hover:bg-surface-alt/80'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+                aria-label={label}
+              >
+                {/* Removed the text label and increased icon size for better visibility */}
+                <Icon className="h-6 w-6" aria-hidden="true" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MobileNav.tsx
+++ b/the-scrum-book-nextjs/src/components/MobileNav.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import React from 'react';
+import type { View, AuthUser } from '@/types';
+import {
+  CalendarIcon,
+  CalendarDaysIcon,
+  TableCellsIcon,
+  ListBulletIcon,
+  UserCircleIcon,
+  UsersIcon,
+  LocationMarkerIcon,
+  BuildingStadiumIcon,
+  InformationCircleIcon,
+  TrophyIcon,
+  ChartBarIcon,
+  LogoIcon,
+  XMarkIcon,
+  ArrowLeftOnRectangleIcon,
+} from './Icons';
+
+interface MobileNavProps {
+  currentView: View;
+  setView: (view: View) => void;
+  currentUser: AuthUser | null;
+  isOpen: boolean;
+  onClose: () => void;
+  theme: 'light' | 'dark';
+  onLogout: () => void;
+}
+
+type NavItem = {
+  view: View;
+  label: string;
+  description?: string;
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  isProtected?: boolean;
+};
+
+const primaryItems: NavItem[] = [
+  { view: 'UPCOMING', label: 'Next 7 Days', description: 'Quick look at the coming week', icon: CalendarIcon },
+  { view: 'NEARBY', label: 'Nearby', description: 'Matches closest to you', icon: LocationMarkerIcon },
+  { view: 'MATCH_DAY', label: 'Fixtures & Results', description: 'Full calendar of the season', icon: CalendarDaysIcon },
+  { view: 'LEAGUE_TABLE', label: 'League Table', description: 'Track club standings', icon: TableCellsIcon },
+  { view: 'GROUNDS', label: 'Grounds', description: 'Explore Super League stadiums', icon: BuildingStadiumIcon },
+  { view: 'COMMUNITY', label: 'Community', description: 'Connect with fellow supporters', icon: UsersIcon },
+  { view: 'ABOUT', label: 'About', description: 'Learn about The Scrum Book', icon: InformationCircleIcon },
+];
+
+const supporterItems: NavItem[] = [
+  { view: 'MY_MATCHES', label: 'My Matches', description: 'Your attended fixtures', icon: ListBulletIcon, isProtected: true },
+  { view: 'STATS', label: 'My Stats', description: 'Personal supporter insights', icon: ChartBarIcon, isProtected: true },
+  { view: 'BADGES', label: 'Badges', description: 'Earned supporter milestones', icon: TrophyIcon, isProtected: true },
+  { view: 'PROFILE', label: 'Profile', description: 'Manage your supporter profile', icon: UserCircleIcon, isProtected: true },
+];
+
+export const MobileNav: React.FC<MobileNavProps> = ({
+  currentView,
+  setView,
+  currentUser,
+  isOpen,
+  onClose,
+  theme,
+  onLogout,
+}) => {
+  const handleNavigate = (view: View) => {
+    setView(view);
+    onClose();
+  };
+
+  const handleLogout = () => {
+    onLogout();
+    onClose();
+  };
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-30 bg-black/60 backdrop-blur-sm transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'pointer-events-none opacity-0'
+        }`}
+        onClick={onClose}
+        aria-hidden={!isOpen}
+      />
+      <nav
+        className={`fixed inset-y-0 right-0 z-40 w-80 max-w-[calc(100%-4rem)] transform bg-surface border-l border-border shadow-2xl transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-hidden={!isOpen}
+        aria-label="Mobile navigation"
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between px-5 py-5 border-b border-border/70 bg-surface-alt/60 backdrop-blur">
+            <div className="flex items-center gap-3">
+              <LogoIcon className="h-10 w-10" theme={theme} />
+              <div className="flex flex-col">
+                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+                <span className="text-lg font-heading text-text-strong">Matchday Companion</span>
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="rounded-full p-2 text-text-subtle transition-colors hover:bg-surface hover:text-text"
+              aria-label="Close navigation menu"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
+          <div className="flex-1 px-5 py-6 space-y-6 overflow-y-auto">
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle mb-4">Main Navigation</h2>
+              <ul className="space-y-2">
+                {primaryItems.map(({ view, label, description, icon: Icon }) => {
+                  const isActive = currentView === view;
+                  return (
+                    <li key={view}>
+                      <button
+                        onClick={() => handleNavigate(view)}
+                        className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
+                          isActive
+                            ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
+                            : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                        }`}
+                      >
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
+                              isActive
+                                ? 'border-primary/40 bg-primary/20 text-primary'
+                                : 'border-border/70 bg-surface text-text-subtle'
+                            }`}
+                          >
+                            <Icon className="h-5 w-5" />
+                          </span>
+                          <div>
+                            <p className="font-heading text-lg text-text-strong">{label}</p>
+                            {description && <p className="text-xs text-text-subtle">{description}</p>}
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle mb-4">Supporter Hub</h2>
+              <ul className="space-y-2">
+                {supporterItems.map(({ view, label, description, icon: Icon, isProtected }) => {
+                  const isActive = currentView === view;
+                  const disabled = isProtected && !currentUser;
+                  return (
+                    <li key={view}>
+                      <button
+                        onClick={() => !disabled && handleNavigate(view)}
+                        className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
+                          disabled
+                            ? 'cursor-not-allowed border-border/40 bg-surface-alt/30 text-text-subtle'
+                            : isActive
+                              ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
+                              : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                        }`}
+                        aria-disabled={disabled}
+                      >
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
+                              isActive
+                                ? 'border-primary/40 bg-primary/20 text-primary'
+                                : 'border-border/70 bg-surface text-text-subtle'
+                            }`}
+                          >
+                            <Icon className="h-5 w-5" />
+                          </span>
+                          <div>
+                            <p className="font-heading text-lg text-text-strong">{label}</p>
+                            {description && <p className="text-xs text-text-subtle">{description}</p>}
+                            {disabled && (
+                              <p className="text-[11px] font-medium text-danger mt-1">Login required</p>
+                            )}
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            <div className="rounded-xl border border-border/60 bg-surface-alt/60 px-4 py-4 text-sm text-text-subtle">
+              <p className="font-heading text-text-strong text-lg">Matchday Tip</p>
+              <p className="mt-2">
+                Keep your supporter log up to date to unlock new badges and season-long stats. Tap “My Matches” after every game you attend.
+              </p>
+            </div>
+          </div>
+          {currentUser && (
+            <div className="border-t border-border/70 bg-surface/80 px-5 py-4">
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="w-full inline-flex items-center justify-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle transition-colors hover:text-text hover:border-border hover:bg-surface-alt/70"
+              >
+                <ArrowLeftOnRectangleIcon className="h-5 w-5" />
+                <span>Logout</span>
+              </button>
+            </div>
+          )}
+        </div>
+      </nav>
+    </>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/MyMatchesView.tsx
+++ b/the-scrum-book-nextjs/src/components/MyMatchesView.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import type { AttendedMatch } from '@/types';
+import { TrashIcon, CalendarIcon, LocationMarkerIcon, RefreshIcon, CameraIcon } from './Icons';
+import { TeamLogo } from './TeamLogo';
+import { useAuth } from '@/contexts/AuthContext';
+import { PhotoUploadModal } from './PhotoUploadModal';
+import { PhotoViewerModal } from './PhotoViewerModal';
+import { formatDateUK } from '@/utils/date';
+
+interface MyMatchesViewProps {
+    attendedMatches: AttendedMatch[];
+    onRemove: (matchId: string) => void;
+}
+
+export const MyMatchesView: React.FC<MyMatchesViewProps> = ({ attendedMatches, onRemove }) => {
+    const [yearFilter, setYearFilter] = useState('all');
+    const [competitionFilter, setCompetitionFilter] = useState('all');
+    const [sortBy, setSortBy] = useState('attendedDesc');
+    
+    const [uploadModalMatch, setUploadModalMatch] = useState<AttendedMatch | null>(null);
+    const [viewModalMatch, setViewModalMatch] = useState<AttendedMatch | null>(null);
+    const [isUploading, setIsUploading] = useState(false);
+    const { addPhotoToMatch } = useAuth();
+
+    const handleUploadPhoto = async (matchId: string, file: File) => {
+        setIsUploading(true);
+        try {
+            await addPhotoToMatch(matchId, file);
+            setUploadModalMatch(null);
+        } catch (error) {
+            console.error("Upload failed in view:", error);
+            // Optionally, show an error message to the user in the modal
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    const { availableYears, availableCompetitions } = useMemo(() => {
+        const years = new Set<string>();
+        const competitions = new Set<string>();
+        attendedMatches.forEach(am => {
+            years.add(new Date(am.match.startTime).getFullYear().toString());
+            competitions.add(am.match.competition?.name || 'Other');
+        });
+        return {
+            availableYears: Array.from(years).sort((a, b) => b.localeCompare(a)),
+            availableCompetitions: Array.from(competitions).sort()
+        };
+    }, [attendedMatches]);
+
+    const filteredAndSortedMatches = useMemo(() => {
+        return [...attendedMatches]
+            .filter(am => {
+                const matchYear = new Date(am.match.startTime).getFullYear().toString();
+                const matchCompetition = am.match.competition?.name || 'Other';
+                const yearMatch = yearFilter === 'all' || matchYear === yearFilter;
+                const competitionMatch = competitionFilter === 'all' || matchCompetition === competitionFilter;
+                return yearMatch && competitionMatch;
+            })
+            .sort((a, b) => {
+                switch (sortBy) {
+                    case 'attendedAsc':
+                        return new Date(a.attendedOn).getTime() - new Date(b.attendedOn).getTime();
+                    case 'matchDesc':
+                        return new Date(b.match.startTime).getTime() - new Date(a.match.startTime).getTime();
+                    case 'matchAsc':
+                        return new Date(a.match.startTime).getTime() - new Date(b.match.startTime).getTime();
+                    case 'attendedDesc':
+                    default:
+                        return new Date(b.attendedOn).getTime() - new Date(a.attendedOn).getTime();
+                }
+            });
+    }, [attendedMatches, yearFilter, competitionFilter, sortBy]);
+
+    const handleClearFilters = () => {
+        setYearFilter('all');
+        setCompetitionFilter('all');
+        setSortBy('attendedDesc');
+    };
+
+    if (attendedMatches.length === 0) {
+        return (
+            <div className="text-center py-20 bg-surface rounded-md">
+                <h2 className="text-2xl font-bold text-text-strong">No Matches Attended Yet</h2>
+                <p className="text-text-subtle mt-2">Go to "Fixtures & Results" and click "I was there" to build your collection of attended games!</p>
+            </div>
+        );
+    }
+
+    const SelectControl: React.FC<{ label: string, value: string, onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void, children: React.ReactNode }> = ({ label, value, onChange, children }) => (
+        <div className="flex flex-col">
+            <label className="text-xs font-semibold text-text-subtle mb-1">{label}</label>
+            <select
+                value={value}
+                onChange={onChange}
+                className="bg-surface text-text placeholder-text-subtle border border-border rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary h-10"
+            >
+                {children}
+            </select>
+        </div>
+    );
+    
+    return (
+        <div className="space-y-6">
+            <h1 className="text-3xl font-bold text-text-strong border-b border-border pb-4">My Attended Matches ({attendedMatches.length})</h1>
+            
+            <div className="bg-surface p-4 rounded-md shadow-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 items-end">
+                    <SelectControl label="Filter by Year" value={yearFilter} onChange={(e) => setYearFilter(e.target.value)}>
+                        <option value="all">All Years</option>
+                        {availableYears.map(year => <option key={year} value={year}>{year}</option>)}
+                    </SelectControl>
+
+                    <SelectControl label="Filter by Competition" value={competitionFilter} onChange={(e) => setCompetitionFilter(e.target.value)}>
+                        <option value="all">All Competitions</option>
+                        {availableCompetitions.map(comp => <option key={comp} value={comp}>{comp}</option>)}
+                    </SelectControl>
+                    
+                    <SelectControl label="Sort By" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+                        <option value="attendedDesc">Date Attended (Newest)</option>
+                        <option value="attendedAsc">Date Attended (Oldest)</option>
+                        <option value="matchDesc">Match Date (Newest)</option>
+                        <option value="matchAsc">Match Date (Oldest)</option>
+                    </SelectControl>
+                    
+                    <button
+                        onClick={handleClearFilters}
+                        className="flex items-center justify-center gap-2 bg-surface-alt text-text-subtle font-semibold py-2 px-4 rounded-md hover:bg-border/50 transition-colors h-10"
+                    >
+                        <RefreshIcon className="w-5 h-5"/>
+                        Clear
+                    </button>
+                </div>
+            </div>
+
+            {filteredAndSortedMatches.length === 0 ? (
+                 <div className="text-center py-20 bg-surface rounded-md">
+                    <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
+                    <p className="text-text-subtle mt-2">Try adjusting your filters to find the matches you're looking for.</p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {filteredAndSortedMatches.map((attendedMatch) => {
+                        const { match, attendedOn, photoUrl } = attendedMatch;
+                        return (
+                            <div key={match.id} className="bg-surface rounded-md shadow-card flex flex-col text-text-strong overflow-hidden">
+                                {photoUrl ? (
+                                    <button onClick={() => setViewModalMatch(attendedMatch)} className="relative aspect-video bg-surface-alt group cursor-pointer">
+                                        <img src={photoUrl} alt={`${match.homeTeam.name} vs ${match.awayTeam.name}`} className="w-full h-full object-cover" />
+                                        <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                            <span className="text-white font-bold text-sm bg-black/50 px-3 py-1 rounded-md">View Photo</span>
+                                        </div>
+                                    </button>
+                                ) : (
+                                    <button onClick={() => setUploadModalMatch(attendedMatch)} className="aspect-video bg-surface-alt flex items-center justify-center border-b border-border hover:bg-border/50 transition-colors">
+                                        <div className="flex flex-col items-center gap-2 text-text-subtle">
+                                            <CameraIcon className="w-8 h-8"/>
+                                            <span className="text-sm font-semibold">Add Photo</span>
+                                        </div>
+                                    </button>
+                                )}
+                                <div className="p-4 flex-grow">
+                                    <div className="flex justify-between items-start mb-3">
+                                        <p className="text-sm text-primary font-semibold">{match.competition?.name || 'Super League'}</p>
+                                        <p className="text-xs text-text-subtle">
+                                            Attended: {formatDateUK(attendedOn)}
+                                        </p>
+                                    </div>
+
+                                    <div className="flex items-center justify-between gap-2 mb-2">
+                                        <div className="flex items-center gap-2 w-2/5 truncate">
+                                            <TeamLogo teamId={match.homeTeam?.id} teamName={match.homeTeam?.name || 'Home Team'} size="small" />
+                                            <span className="font-semibold text-sm">{match.homeTeam?.name || 'Home Team'}</span>
+                                        </div>
+                                        
+                                        {match.status === 'FULL-TIME' ? (
+                                            <div className="font-extrabold text-lg text-primary [font-variant-numeric:tabular-nums]">
+                                                {match.scores.home} - {match.scores.away}
+                                            </div>
+                                        ) : (
+                                            <div className="font-semibold text-base text-text-subtle">
+                                                {new Date(match.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })}
+                                            </div>
+                                        )}
+
+                                        <div className="flex items-center gap-2 w-2/5 truncate justify-end">
+                                            <span className="font-semibold text-sm text-right">{match.awayTeam?.name || 'Away Team'}</span>
+                                            <TeamLogo teamId={match.awayTeam?.id} teamName={match.awayTeam?.name || 'Away Team'} size="small" />
+                                        </div>
+                                    </div>
+
+                                    <div className="text-xs text-text-subtle space-y-1 mt-4">
+                                        <div className="flex items-center gap-2">
+                                            <LocationMarkerIcon className="w-3 h-3"/>
+                                            <span>{match.venue}</span>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <CalendarIcon className="w-3 h-3"/>
+                                            <span>Match Date: {formatDateUK(match.startTime)}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="bg-surface-alt p-2 flex justify-end items-center gap-2 rounded-b-md border-t border-border">
+                                    <button onClick={() => setUploadModalMatch(attendedMatch)} className="text-info hover:bg-info/10 transition-colors p-1 rounded-full" aria-label="Upload or change photo">
+                                        <CameraIcon className="w-5 h-5"/>
+                                    </button>
+                                    <button onClick={() => onRemove(match.id)} className="text-danger hover:bg-danger/10 transition-colors p-1 rounded-full" aria-label="Remove attended match">
+                                        <TrashIcon className="w-5 h-5"/>
+                                    </button>
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+
+            <PhotoUploadModal 
+                match={uploadModalMatch} 
+                isOpen={!!uploadModalMatch} 
+                onClose={() => setUploadModalMatch(null)}
+                onUpload={handleUploadPhoto}
+                isUploading={isUploading}
+            />
+            <PhotoViewerModal 
+                attendedMatch={viewModalMatch}
+                isOpen={!!viewModalMatch}
+                onClose={() => setViewModalMatch(null)}
+            />
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/NearbyMatchesView.tsx
+++ b/the-scrum-book-nextjs/src/components/NearbyMatchesView.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useEffect, useMemo } from 'react';
+import type { Match } from '@/types';
+import { MatchListItem } from './MatchListItem';
+import { LoadingSpinner } from './LoadingSpinner';
+import { AlertTriangleIcon } from './Icons';
+import { useGeolocation } from '@/hooks/useGeolocation';
+import { getDistance } from '@/utils/geolocation';
+import { ALL_VENUES } from '@/services/mockData';
+
+interface NearbyMatch extends Match {
+  distance: number;
+}
+
+interface NearbyMatchesViewProps {
+  matches: Match[];
+  attendedMatchIds: string[];
+  onAttend: (match: Match) => void;
+}
+
+export const NearbyMatchesView: React.FC<NearbyMatchesViewProps> = ({ matches, attendedMatchIds, onAttend }) => {
+  const { position, isLoading, error, requestLocation } = useGeolocation();
+
+  useEffect(() => {
+    requestLocation();
+  }, [requestLocation]);
+
+  const upcomingMatches = useMemo(
+    () => matches.filter(match => new Date(match.startTime) > new Date() && match.status === 'SCHEDULED'),
+    [matches],
+  );
+
+  const sortedMatches = useMemo<NearbyMatch[]>(() => {
+    if (!position) {
+      return [];
+    }
+
+    return upcomingMatches
+      .map(match => {
+        const venue = ALL_VENUES.find(v => v.name === match.venue);
+        if (!venue) {
+          return null;
+        }
+
+        const distance = getDistance(position.lat, position.lon, venue.lat, venue.lon);
+        return { ...match, distance };
+      })
+      .filter((match): match is NearbyMatch => match !== null)
+      .sort((a, b) => a.distance - b.distance);
+  }, [position, upcomingMatches]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center">
+        <LoadingSpinner />
+        <p className="mt-4 text-center text-text-subtle">Getting your location to find nearby matches...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center rounded-md bg-surface p-8 text-center shadow-card">
+        <AlertTriangleIcon className="mb-4 h-12 w-12 text-danger" />
+        <h2 className="mb-2 text-xl font-bold text-text-strong">Location Error</h2>
+        <p className="mb-6 max-w-md text-text-subtle">
+          {error.code === 1
+            ? "You've denied location access. Please enable it in your browser settings to use this feature."
+            : 'Could not determine your location. Please check your connection and try again.'}
+        </p>
+        <button
+          onClick={requestLocation}
+          className="rounded-md bg-primary px-6 py-2 font-semibold text-white transition-colors duration-200 hover:bg-primary/90"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="border-b border-border pb-4">
+        <h1 className="text-3xl font-bold text-text-strong">Nearby Matches</h1>
+        <p className="mt-1 text-text-subtle">Upcoming Super League matches, sorted by distance.</p>
+      </div>
+
+      {sortedMatches.length === 0 ? (
+        <div className="rounded-md bg-surface py-20 text-center">
+          <h2 className="text-2xl font-bold text-text-strong">No Nearby Matches</h2>
+          <p className="mt-2 text-text-subtle">There are no upcoming matches near your location.</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {sortedMatches.map(match => (
+            <MatchListItem
+              key={match.id}
+              match={match}
+              isAttended={attendedMatchIds.includes(match.id)}
+              onAttend={onAttend}
+              distance={match.distance}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/PhotoUploadModal.tsx
+++ b/the-scrum-book-nextjs/src/components/PhotoUploadModal.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import type { AttendedMatch } from '@/types';
+import { XMarkIcon, ArrowUpTrayIcon, CameraIcon, MiniSpinnerIcon } from './Icons';
+
+interface PhotoUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUpload: (matchId: string, file: File) => Promise<void>;
+  isUploading: boolean;
+  match: AttendedMatch | null;
+}
+
+export const PhotoUploadModal: React.FC<PhotoUploadModalProps> = ({ isOpen, onClose, onUpload, isUploading, match }) => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  useEffect(() => {
+    if (isOpen && match) {
+      setPreviewUrl(match.photoUrl || null);
+      setSelectedFile(null);
+    }
+  }, [isOpen, match]);
+
+  if (!isOpen || !match) return null;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreviewUrl(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+  
+  const handleSave = () => {
+    if (selectedFile) {
+      onUpload(match.match.id, selectedFile);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="photo-modal-title">
+      <div className="bg-surface rounded-xl shadow-lg w-full max-w-md max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 id="photo-modal-title" className="text-xl font-bold text-text-strong">
+            {match.photoUrl ? 'Change' : 'Add'} Photo
+          </h2>
+          <button onClick={onClose} className="p-1 rounded-full text-text-subtle hover:bg-surface-alt" aria-label="Close">
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto space-y-4">
+            <p className="text-sm text-text-subtle text-center">
+              {match.match.homeTeam.name} vs {match.match.awayTeam.name}
+            </p>
+            <div className="flex items-center justify-center w-full aspect-video mx-auto rounded-lg bg-surface-alt border-2 border-dashed border-border overflow-hidden">
+                {previewUrl ? (
+                    <img src={previewUrl} alt="Photo preview" className="w-full h-full object-cover" />
+                ) : (
+                    <div className="flex flex-col items-center gap-2 text-text-subtle">
+                        <CameraIcon className="w-12 h-12" />
+                        <span>Photo Preview</span>
+                    </div>
+                )}
+            </div>
+            
+            <div>
+                <input type="file" accept="image/*" ref={fileInputRef} onChange={handleFileChange} className="hidden" />
+                <button 
+                    onClick={() => fileInputRef.current?.click()}
+                    className="w-full flex items-center justify-center gap-2 text-center bg-primary/10 text-primary font-semibold py-2.5 px-4 rounded-md hover:bg-primary/20 transition-colors"
+                >
+                    <ArrowUpTrayIcon className="w-5 h-5"/>
+                    Choose an Image
+                </button>
+            </div>
+        </div>
+
+        <div className="p-4 bg-surface-alt border-t border-border mt-auto">
+            <button 
+                onClick={handleSave}
+                disabled={!selectedFile || isUploading}
+                className="w-full flex items-center justify-center gap-2 bg-secondary text-white font-semibold py-2.5 px-4 rounded-md hover:bg-secondary/90 transition-colors disabled:bg-secondary/50 disabled:cursor-not-allowed"
+            >
+                {isUploading ? (
+                    <>
+                        <MiniSpinnerIcon className="w-5 h-5" />
+                        Uploading...
+                    </>
+                ) : 'Save Photo'}
+            </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/PhotoViewerModal.tsx
+++ b/the-scrum-book-nextjs/src/components/PhotoViewerModal.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { AttendedMatch } from '@/types';
+import { ShareIcon, XMarkIcon } from './Icons';
+import { TeamLogo } from './TeamLogo';
+import { formatDateUK } from '@/utils/date';
+
+interface PhotoViewerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  attendedMatch: AttendedMatch | null;
+}
+
+export const PhotoViewerModal: React.FC<PhotoViewerModalProps> = ({ isOpen, onClose, attendedMatch }) => {
+  const [isShareMenuOpen, setIsShareMenuOpen] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  if (!isOpen || !attendedMatch || !attendedMatch.photoUrl) return null;
+
+  const { match, attendedOn, photoUrl } = attendedMatch;
+
+  const shareDetails = useMemo(() => {
+    const formattedDate = new Date(attendedOn).toLocaleDateString();
+    const scoreLine = `${match.homeTeam.name} ${match.scores.home}-${match.scores.away} ${match.awayTeam.name}`;
+    const text = `Matchday memory: ${scoreLine} at ${match.venue} on ${formattedDate}.`;
+
+    return {
+      shareUrl: photoUrl,
+      shareText: text,
+      shareTitle: `${match.homeTeam.name} vs ${match.awayTeam.name} matchday memory`,
+      emailBody: `${text}\n\n${photoUrl}`,
+    };
+  }, [attendedOn, match, photoUrl]);
+
+  const attemptNativeShare = async () => {
+    if (typeof navigator === 'undefined' || !('share' in navigator)) {
+      return false;
+    }
+
+    try {
+      await (navigator as Navigator & { share: (data: ShareData) => Promise<void> }).share({
+        title: shareDetails.shareTitle,
+        text: shareDetails.shareText,
+        url: shareDetails.shareUrl,
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        // User dismissed the native share sheet; treat as handled.
+        return true;
+      }
+      return false;
+    }
+  };
+
+  const handleShareClick = async () => {
+    if (isShareMenuOpen) {
+      setIsShareMenuOpen(false);
+      return;
+    }
+
+    const wasShared = await attemptNativeShare();
+
+    if (!wasShared) {
+      setIsShareMenuOpen(true);
+    }
+  };
+
+  const handleOpenShareTarget = useCallback((url: string) => {
+    if (typeof window === 'undefined') return;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const handleCopyLink = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      setCopyState('error');
+      setTimeout(() => setCopyState('idle'), 2000);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareDetails.shareUrl);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+
+    setTimeout(() => setCopyState('idle'), 2000);
+  };
+
+  const shareTargets = useMemo(() => {
+    const encodedMessage = encodeURIComponent(`${shareDetails.shareText} ${shareDetails.shareUrl}`);
+    const encodedUrl = encodeURIComponent(shareDetails.shareUrl);
+    const encodedQuote = encodeURIComponent(shareDetails.shareText);
+    const encodedEmailBody = encodeURIComponent(shareDetails.emailBody);
+
+    return [
+      {
+        label: 'WhatsApp',
+        action: () => handleOpenShareTarget(`https://wa.me/?text=${encodedMessage}`),
+      },
+      {
+        label: 'Instagram',
+        action: () => handleOpenShareTarget(`https://www.instagram.com/direct/new/?text=${encodedMessage}`),
+      },
+      {
+        label: 'Facebook',
+        action: () => handleOpenShareTarget(`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedQuote}`),
+      },
+      {
+        label: 'Snapchat',
+        action: () => handleOpenShareTarget(`https://www.snapchat.com/scan?attachmentUrl=${encodedUrl}`),
+      },
+      {
+        label: 'Email',
+        action: () => handleOpenShareTarget(`mailto:?subject=${encodeURIComponent(shareDetails.shareTitle)}&body=${encodedEmailBody}`),
+      },
+    ];
+  }, [handleOpenShareTarget, shareDetails]);
+
+  return (
+    <div 
+      className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4 backdrop-blur-sm" 
+      onClick={onClose} 
+      role="dialog" 
+      aria-modal="true"
+    >
+      <div 
+        className="bg-surface rounded-xl shadow-lg w-full max-w-3xl max-h-[90vh] flex flex-col" 
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="relative">
+          <img src={photoUrl} alt={`Photo from ${match.homeTeam.name} vs ${match.awayTeam.name}`} className="w-full h-auto max-h-[70vh] object-contain rounded-t-xl" />
+          <button
+            onClick={handleShareClick}
+            className="absolute top-3 left-3 p-1.5 rounded-full text-white bg-black/50 hover:bg-black/70"
+            aria-label="Share matchday memory"
+          >
+            <ShareIcon className="w-6 h-6" />
+          </button>
+          <button
+            onClick={onClose}
+            className="absolute top-3 right-3 p-1.5 rounded-full text-white bg-black/50 hover:bg-black/70"
+            aria-label="Close"
+          >
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="p-4 border-t border-border bg-surface-alt rounded-b-xl">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2 truncate">
+              <TeamLogo teamId={match.homeTeam.id} teamName={match.homeTeam.name} size="small" />
+              <span className="font-semibold">{match.homeTeam.name}</span>
+              <span className="text-primary font-bold">{match.scores.home}</span>
+            </div>
+            <span className="text-text-subtle font-bold">vs</span>
+            <div className="flex items-center gap-2 truncate justify-end">
+              <span className="text-primary font-bold">{match.scores.away}</span>
+              <span className="font-semibold">{match.awayTeam.name}</span>
+              <TeamLogo teamId={match.awayTeam.id} teamName={match.awayTeam.name} size="small" />
+            </div>
+          </div>
+          <p className="text-xs text-text-subtle text-center mt-2">
+            {match.venue} &bull; Attended on {formatDateUK(attendedOn)}
+          </p>
+          {(isShareMenuOpen || copyState === 'copied' || copyState === 'error') && (
+            <div className="mt-4 border-t border-border pt-4">
+              <p className="text-sm font-semibold text-text">Share this memory</p>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                {shareTargets.map(target => (
+                  <button
+                    key={target.label}
+                    onClick={target.action}
+                    className="rounded-lg border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:border-primary/60 hover:text-primary transition-colors"
+                  >
+                    {target.label}
+                  </button>
+                ))}
+                <button
+                  onClick={handleCopyLink}
+                  className="rounded-lg border border-dashed border-border px-3 py-2 text-sm font-medium text-text hover:border-primary/60 hover:text-primary transition-colors"
+                >
+                  {copyState === 'copied' ? 'Link copied!' : copyState === 'error' ? 'Copy failed' : 'Copy link'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/PredictionGamesView.tsx
+++ b/the-scrum-book-nextjs/src/components/PredictionGamesView.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import React, { useMemo, useState, useEffect } from 'react';
+import type {
+  Match,
+  Prediction,
+  PredictionOutcome,
+  PredictionConfidence,
+  SaveUserPredictionInput,
+} from '@/types';
+import { LoadingSpinner } from './LoadingSpinner';
+
+interface PredictionGamesViewProps {
+  matches: Match[];
+  predictions: Prediction[];
+  onSavePrediction: (input: SaveUserPredictionInput) => Promise<void> | void;
+  onDeletePrediction: (matchId: string) => Promise<void> | void;
+}
+
+const outcomeLabels: Record<PredictionOutcome, string> = {
+  HOME_WIN: 'Home win',
+  AWAY_WIN: 'Away win',
+  DRAW: 'Draw',
+};
+
+const confidenceLabels: Record<PredictionConfidence, string> = {
+  LOW: 'Low',
+  MEDIUM: 'Medium',
+  HIGH: 'High',
+};
+
+const getMatchKickoff = (match: Match) =>
+  new Date(match.startTime).toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+export const PredictionGamesView: React.FC<PredictionGamesViewProps> = ({
+  matches,
+  predictions,
+  onSavePrediction,
+  onDeletePrediction,
+}) => {
+  const upcomingMatches = useMemo(
+    () =>
+      matches
+        .filter((match) => match.status === 'SCHEDULED')
+        .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()),
+    [matches]
+  );
+
+  const [selectedMatchId, setSelectedMatchId] = useState<string>(upcomingMatches[0]?.id ?? '');
+  const [outcome, setOutcome] = useState<PredictionOutcome>('HOME_WIN');
+  const [confidence, setConfidence] = useState<PredictionConfidence>('MEDIUM');
+  const [notes, setNotes] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMatchId && upcomingMatches.length > 0) {
+      setSelectedMatchId(upcomingMatches[0].id);
+      return;
+    }
+
+    const existingPrediction = predictions.find((prediction) => prediction.matchId === selectedMatchId);
+    if (existingPrediction) {
+      setOutcome(existingPrediction.outcome);
+      setConfidence(existingPrediction.confidence ?? 'MEDIUM');
+      setNotes(existingPrediction.notes ?? '');
+    } else {
+      setOutcome('HOME_WIN');
+      setConfidence('MEDIUM');
+      setNotes('');
+    }
+  }, [predictions, selectedMatchId, upcomingMatches]);
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!selectedMatchId) {
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      await onSavePrediction({
+        matchId: selectedMatchId,
+        outcome,
+        confidence,
+        notes: notes.trim() ? notes.trim() : undefined,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (matchId: string) => {
+    try {
+      setIsDeleting(matchId);
+      await onDeletePrediction(matchId);
+      if (matchId === selectedMatchId) {
+        setNotes('');
+      }
+    } finally {
+      setIsDeleting(null);
+    }
+  };
+
+  if (!matches.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12">
+        <LoadingSpinner />
+        <p className="mt-4 text-text-subtle">Loading fixtures for prediction games...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <section className="rounded-xl border border-surface-muted bg-surface p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-text">Make your prediction</h2>
+        {upcomingMatches.length === 0 ? (
+          <p className="mt-4 text-text-subtle">There are no upcoming matches available for predictions right now.</p>
+        ) : (
+          <form className="mt-6 space-y-6" onSubmit={handleSubmit}>
+            <label className="block text-sm font-medium text-text-subtle">
+              Match
+              <select
+                className="mt-1 w-full rounded-md border border-surface-muted bg-surface-strong px-3 py-2 text-text"
+                value={selectedMatchId}
+                onChange={(event) => setSelectedMatchId(event.target.value)}
+              >
+                {upcomingMatches.map((match) => (
+                  <option key={match.id} value={match.id}>
+                    {match.homeTeam.name} vs {match.awayTeam.name} — {getMatchKickoff(match)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <fieldset className="space-y-2">
+              <legend className="text-sm font-medium text-text-subtle">Outcome</legend>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {Object.entries(outcomeLabels).map(([value, label]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    className={`rounded-lg border px-3 py-2 text-sm transition focus:outline-none focus:ring-2 focus:ring-primary ${
+                      outcome === value
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-surface-muted bg-surface-strong text-text-subtle hover:border-primary'
+                    }`}
+                    onClick={() => setOutcome(value as PredictionOutcome)}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <label className="block text-sm font-medium text-text-subtle">
+              Confidence
+              <select
+                className="mt-1 w-full rounded-md border border-surface-muted bg-surface-strong px-3 py-2 text-text"
+                value={confidence}
+                onChange={(event) => setConfidence(event.target.value as PredictionConfidence)}
+              >
+                {Object.entries(confidenceLabels).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block text-sm font-medium text-text-subtle">
+              Notes <span className="font-normal text-text-muted">(optional)</span>
+              <textarea
+                className="mt-1 w-full rounded-md border border-surface-muted bg-surface-strong px-3 py-2 text-sm text-text"
+                rows={3}
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                placeholder="Share your reasoning for this prediction..."
+              />
+            </label>
+
+            <div className="flex items-center justify-end gap-3">
+              <button
+                type="submit"
+                className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-primary/60"
+                disabled={isSaving || !selectedMatchId}
+              >
+                {isSaving ? 'Saving...' : 'Save prediction'}
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
+
+      <section className="rounded-xl border border-surface-muted bg-surface p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-text">Your predictions</h2>
+          <span className="text-sm text-text-subtle">{predictions.length} saved</span>
+        </div>
+
+        {predictions.length === 0 ? (
+          <p className="mt-4 text-text-subtle">
+            You haven't saved any predictions yet. Pick an upcoming match and lock in your call!
+          </p>
+        ) : (
+          <ul className="mt-6 space-y-4">
+            {predictions
+              .slice()
+              .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+              .map((prediction) => {
+                const match = matches.find((item) => item.id === prediction.matchId);
+                return (
+                  <li key={prediction.id} className="rounded-lg border border-surface-muted bg-surface-strong p-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="text-sm font-semibold text-text">
+                          {match ? `${match.homeTeam.name} vs ${match.awayTeam.name}` : 'Match unavailable'}
+                        </p>
+                        {match && (
+                          <p className="text-xs text-text-muted">Kick-off: {getMatchKickoff(match)}</p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                          {outcomeLabels[prediction.outcome]}
+                        </span>
+                        {prediction.confidence && (
+                          <span className="rounded-full bg-surface px-2 py-1 text-xs text-text-subtle">
+                            {confidenceLabels[prediction.confidence]} confidence
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {prediction.notes && <p className="mt-3 text-sm text-text-subtle">“{prediction.notes}”</p>}
+                    <div className="mt-4 flex items-center justify-between text-xs text-text-muted">
+                      <span>
+                        Last updated: {new Date(prediction.updatedAt).toLocaleString(undefined, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' })}
+                      </span>
+                      <button
+                        type="button"
+                        className="text-xs font-semibold text-destructive hover:text-destructive-dark disabled:cursor-not-allowed"
+                        onClick={() => handleDelete(prediction.matchId)}
+                        disabled={isDeleting === prediction.matchId}
+                      >
+                        {isDeleting === prediction.matchId ? 'Removing...' : 'Remove'}
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default PredictionGamesView;

--- a/the-scrum-book-nextjs/src/components/ProfileView.module.css
+++ b/the-scrum-book-nextjs/src/components/ProfileView.module.css
@@ -1,0 +1,474 @@
+.profilePage {
+  --hero-overlay: linear-gradient(135deg, rgba(17, 46, 114, 0.96), rgba(20, 31, 67, 0.92));
+  --hero-highlight: rgba(30, 139, 255, 0.85);
+  --card-bg: var(--clr-surface);
+  --card-border: rgba(15, 23, 42, 0.08);
+  --card-shadow: 0 32px 60px -30px rgba(15, 23, 42, 0.55);
+  --text-strong: var(--clr-text-strong);
+  --text-subtle: var(--clr-text-subtle);
+
+  min-height: 100%;
+  background: linear-gradient(180deg, rgba(7, 11, 23, 0.15) 0%, rgba(7, 11, 23, 0) 30%), #f5f7fb;
+  color: var(--text-strong);
+}
+
+.hero {
+  position: relative;
+  padding: clamp(2.5rem, 6vw, 3.75rem) clamp(1.5rem, 5vw, 3rem) clamp(7rem, 12vw, 9rem);
+  overflow: hidden;
+  color: #ecf5ff;
+  background: var(--hero-overlay);
+  border-bottom-left-radius: clamp(3rem, 10vw, 5rem);
+}
+
+.heroBackdrop {
+  position: absolute;
+  inset: 0;
+  background-image: url('../background.png');
+  background-repeat: no-repeat;
+  background-size: 70%;
+  background-position: left top;
+  opacity: 0.25;
+}
+
+.heroContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.avatarWrap {
+  position: relative;
+  width: clamp(96px, 18vw, 120px);
+  height: clamp(96px, 18vw, 120px);
+  flex-shrink: 0;
+}
+
+.avatarImage,
+.avatarPlaceholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.2);
+  border: 4px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 24px 40px -24px rgba(0, 0, 0, 0.55);
+  color: rgba(236, 245, 255, 0.7);
+}
+
+.avatarPlaceholder {
+  padding: 12px;
+}
+
+.avatarEdit {
+  position: absolute;
+  right: 4px;
+  bottom: 6px;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hero-highlight);
+  border: 3px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 18px 30px -12px rgba(30, 139, 255, 0.9);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.avatarEdit:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 24px 40px -16px rgba(30, 139, 255, 0.9);
+}
+
+.avatarEdit svg {
+  width: 18px;
+  height: 18px;
+}
+
+.identityText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.logoWrap {
+  width: clamp(96px, 18vw, 120px);
+  height: clamp(96px, 18vw, 120px);
+  flex-shrink: 0;
+}
+
+.logoImage {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 14px rgba(0, 0, 0, 0.22));
+}
+
+.nameForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.nameForm input {
+  flex: 1;
+  min-width: 200px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 16px;
+  padding: 0.65rem 1rem;
+  color: inherit;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.nameForm button {
+  border: none;
+  border-radius: 16px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 700;
+  background: #fff;
+  color: #0a1e4a;
+  cursor: pointer;
+}
+
+.nameButton {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.nameButton svg {
+  width: 22px;
+  height: 22px;
+  opacity: 0.65;
+}
+
+.nameButton:hover svg {
+  opacity: 1;
+}
+
+.tagline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(12, 28, 74, 0.55);
+  backdrop-filter: blur(4px);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.tagline svg {
+  width: 1rem;
+  height: 1rem;
+  color: rgba(255, 199, 78, 1);
+}
+
+.teamBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.teamLogoBadge {
+  width: 34px !important;
+  height: 34px !important;
+  box-shadow: 0 12px 24px -18px rgba(0, 0, 0, 0.7) !important;
+}
+
+.statRow {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+  padding: 0;
+}
+
+.statCard {
+  position: relative;
+  display: grid;
+  gap: 0.4rem;
+  justify-items: center;
+  padding: clamp(1.25rem, 4vw, 1.75rem);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  text-align: center;
+}
+
+.statCard svg {
+  width: 28px;
+  height: 28px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.statCard dt {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(236, 245, 255, 0.75);
+}
+
+.statCard dd {
+  margin: 0;
+  font-size: clamp(1.9rem, 5vw, 2.4rem);
+  font-weight: 800;
+  color: #fff;
+}
+
+.mainContent {
+  position: relative;
+  margin-top: clamp(-5.5rem, -9vw, -6.5rem);
+  padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 5vw, 3rem) 3.5rem;
+}
+
+.summaryGrid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.detailCard {
+  background: var(--card-bg);
+  border-radius: 24px;
+  border: 1px solid var(--card-border);
+  box-shadow: var(--card-shadow);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cardHeader h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.cardHeader button {
+  border: none;
+  background: transparent;
+  color: var(--clr-primary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cardBody {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cardBody p {
+  margin: 0;
+  color: var(--text-subtle);
+}
+
+.teamSummary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.teamLogoSummary {
+  width: 58px !important;
+  height: 58px !important;
+  box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.6) !important;
+}
+
+.matchSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.matchSummary p {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.matchScore {
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--clr-primary);
+}
+
+.matchMeta {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.actionCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.quickActions {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.quickActionsRail {
+  position: relative;
+}
+
+.quickActionsRail::-webkit-scrollbar {
+  display: none;
+}
+
+.quickActionsRail {
+  scrollbar-width: none;
+}
+
+.quickActions button {
+  border: none;
+  border-radius: 20px;
+  padding: 1.35rem 1rem;
+  background: var(--card-bg);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 16px 35px -25px rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-strong);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.quickActions button:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 40px -28px rgba(15, 23, 42, 0.75);
+}
+
+.quickActions svg {
+  width: 28px;
+  height: 28px;
+  color: var(--clr-primary);
+}
+
+@media (max-width: 640px) {
+  .hero {
+    border-bottom-left-radius: 2.5rem;
+  }
+
+  .mainContent {
+    margin-top: -4.5rem;
+  }
+
+  .summaryGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'team team'
+      'match quick';
+    gap: 1.25rem;
+  }
+
+  .myTeamCard {
+    grid-area: team;
+  }
+
+  .lastMatchCard {
+    grid-area: match;
+  }
+
+  .actionCard {
+    grid-area: quick;
+  }
+
+  .detailCard {
+    padding: 1.25rem;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .cardBody {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .teamSummary {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .teamLogoSummary {
+    width: 48px !important;
+    height: 48px !important;
+  }
+
+  .quickActions {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(150px, 1fr);
+    overflow-x: auto;
+    padding-bottom: 0.35rem;
+    margin: 0 -0.35rem;
+    padding-left: 0.35rem;
+    scroll-snap-type: x mandatory;
+  }
+
+  .quickActions button {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 1rem 1.15rem;
+    scroll-snap-align: start;
+  }
+
+  .quickActions svg {
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/the-scrum-book-nextjs/src/components/ProfileView.tsx
+++ b/the-scrum-book-nextjs/src/components/ProfileView.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import type { AttendedMatch, User, View } from '@/types';
+import { TeamSelectionModal } from './TeamSelectionModal';
+import { AvatarModal } from './AvatarModal';
+import { TeamLogo } from './TeamLogo';
+import {
+  ArrowRightOnRectangleIcon,
+  BuildingStadiumIcon,
+  ChartBarIcon,
+  ListBulletIcon,
+  LogoIcon,
+  PencilIcon,
+  SparklesIcon,
+  TrophyIcon,
+  UserCircleIcon,
+} from './Icons';
+import { TEAMS } from '@/services/mockData';
+import styles from './ProfileView.module.css';
+import { formatDateUK } from '@/utils/date';
+
+// Helper to get team details by ID
+const getTeamById = (teamId?: string) => {
+  if (!teamId) return undefined;
+  return Object.values(TEAMS).find(team => team.id === teamId);
+};
+
+interface ProfileViewProps {
+  user: User;
+  setUser: (user: Partial<User>) => void;
+  setView: (view: View) => void;
+  attendedMatches: AttendedMatch[];
+  earnedBadgeIds: string[];
+  onLogout: () => void;
+}
+
+export const ProfileView: React.FC<ProfileViewProps> = ({
+  user,
+  setUser,
+  setView,
+  attendedMatches,
+  earnedBadgeIds,
+  onLogout,
+}) => {
+  const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
+  const [isAvatarModalOpen, setIsAvatarModalOpen] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [pendingName, setPendingName] = useState(user.name ?? '');
+
+  useEffect(() => {
+    setPendingName(user.name ?? '');
+  }, [user.name]);
+
+  const favoriteTeam = useMemo(() => getTeamById(user.favoriteTeamId), [user.favoriteTeamId]);
+  const recentMatch = useMemo(() => {
+    if (attendedMatches.length === 0) return null;
+    return [...attendedMatches].sort((a, b) => new Date(b.attendedOn).getTime() - new Date(a.attendedOn).getTime())[0];
+  }, [attendedMatches]);
+
+  const profileTagline = useMemo(() => {
+    const matchCount = attendedMatches.length;
+    if (matchCount >= 20) {
+      return 'Stadium Trailblazer';
+    }
+    if (matchCount >= 10) {
+      return 'Matchday Mainstay';
+    }
+    if (matchCount >= 3) {
+      return 'Clubhouse Regular';
+    }
+    if (matchCount > 0) {
+      return 'Fresh on the Pitch';
+    }
+    return 'Ready for Kick-off';
+  }, [attendedMatches.length]);
+
+  const handleSaveName = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = pendingName.trim();
+    if (trimmed) { setUser({ name: trimmed }); }
+    setIsEditingName(false);
+  };
+  const handleTeamSelect = (teamId: string) => {
+    setUser({ favoriteTeamId: teamId });
+    setIsTeamModalOpen(false);
+  };
+  const handleAvatarSave = (avatarUrl: string) => {
+    setUser({ avatarUrl });
+    setIsAvatarModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className={styles.profilePage}>
+        <section className={styles.hero}>
+          <div className={styles.heroBackdrop} aria-hidden="true" />
+          <div className={styles.heroContent}>
+
+            <div className={styles.topRow}>
+              <div className={styles.avatarWrap}>
+                {user.avatarUrl ? (
+                  <img src={user.avatarUrl} alt="Profile avatar" className={styles.avatarImage} />
+                ) : (
+                  <UserCircleIcon className={styles.avatarPlaceholder} />
+                )}
+                <button
+                  onClick={() => setIsAvatarModalOpen(true)}
+                  className={styles.avatarEdit}
+                  aria-label="Edit avatar"
+                >
+                  <PencilIcon />
+                </button>
+              </div>
+              <div className={styles.logoWrap} aria-hidden="true">
+                <LogoIcon className={styles.logoImage} theme="light" />
+              </div>
+            </div>
+
+            <div className={styles.identityText}>
+              {isEditingName ? (
+                <form onSubmit={handleSaveName} className={styles.nameForm}>
+                  <input
+                    type="text"
+                    value={pendingName}
+                    onChange={(e) => setPendingName(e.target.value)}
+                    onBlur={handleSaveName}
+                    autoFocus
+                  />
+                  <button type="submit">Save</button>
+                </form>
+              ) : (
+                <button type="button" onClick={() => setIsEditingName(true)} className={styles.nameButton}>
+                  <span>{user.name}</span>
+                  <PencilIcon aria-hidden="true" />
+                </button>
+              )}
+              <span className={styles.tagline}>
+                <SparklesIcon aria-hidden="true" />
+                {profileTagline}
+              </span>
+              {favoriteTeam && (
+                <span className={styles.teamBadge}>
+                  <TeamLogo
+                    teamId={favoriteTeam.id}
+                    teamName={favoriteTeam.name}
+                    size="small"
+                    className={styles.teamLogoBadge}
+                  />
+                  {favoriteTeam.name}
+                </span>
+              )}
+            </div>
+
+            <dl className={styles.statRow}>
+              <div className={styles.statCard}>
+                <ListBulletIcon aria-hidden="true" />
+                <dt>Matches Attended</dt>
+                <dd>{attendedMatches.length}</dd>
+              </div>
+              <div className={styles.statCard}>
+                <TrophyIcon aria-hidden="true" />
+                <dt>Badges Unlocked</dt>
+                <dd>{earnedBadgeIds.length}</dd>
+              </div>
+              <div className={styles.statCard}>
+                <BuildingStadiumIcon aria-hidden="true" />
+                <dt>Grounds Visited</dt>
+                <dd>{new Set(attendedMatches.map(am => am.match.venue)).size}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        <main className={styles.mainContent}>
+          <div className={styles.summaryGrid}>
+            <section className={`${styles.detailCard} ${styles.myTeamCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>My Team</h2>
+                <button type="button" onClick={() => setIsTeamModalOpen(true)}>
+                  {favoriteTeam ? 'Change Team' : 'Select Team'}
+                </button>
+              </header>
+              <div className={styles.cardBody}>
+                {favoriteTeam ? (
+                  <div className={styles.teamSummary}>
+                    <TeamLogo
+                      teamId={favoriteTeam.id}
+                      teamName={favoriteTeam.name}
+                      className={styles.teamLogoSummary}
+                    />
+                    <span>{favoriteTeam.name}</span>
+                  </div>
+                ) : (
+                  <p>No favorite team selected yet.</p>
+                )}
+              </div>
+            </section>
+
+            <section className={`${styles.detailCard} ${styles.lastMatchCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>Last Match</h2>
+              </header>
+              <div className={styles.cardBody}>
+                {recentMatch ? (
+                  <div className={styles.matchSummary}>
+                    <p>{`${recentMatch.match.homeTeam.name} vs ${recentMatch.match.awayTeam.name}`}</p>
+                    <span className={styles.matchScore}>{`${recentMatch.match.scores.home} - ${recentMatch.match.scores.away}`}</span>
+                    <span className={styles.matchMeta}>
+                      {recentMatch.match.venue}
+                      {' · '}
+                      {formatDateUK(recentMatch.attendedOn)}
+                    </span>
+                  </div>
+                ) : (
+                  <p>No matches attended yet.</p>
+                )}
+              </div>
+            </section>
+
+            <section className={`${styles.detailCard} ${styles.actionCard}`}>
+              <header className={styles.cardHeader}>
+                <h2>Quick Links</h2>
+              </header>
+              <nav className={`${styles.quickActions} ${styles.quickActionsRail}`} aria-label="Profile navigation">
+                <button type="button" onClick={() => setView('MY_MATCHES')}>
+                  <ListBulletIcon aria-hidden="true" />
+                  <span>My Matches</span>
+                </button>
+                <button type="button" onClick={() => setView('BADGES')}>
+                  <TrophyIcon aria-hidden="true" />
+                  <span>Badges</span>
+                </button>
+                <button type="button" onClick={() => setView('ADMIN')}>
+                  <UserCircleIcon aria-hidden="true" />
+                  <span>Admin Tools</span>
+                </button>
+                <button type="button" onClick={() => setView('STATS')}>
+                  <ChartBarIcon aria-hidden="true" />
+                  <span>My Stats</span>
+                </button>
+                <button type="button" onClick={onLogout}>
+                  <ArrowRightOnRectangleIcon aria-hidden="true" />
+                  <span>Logout</span>
+                </button>
+              </nav>
+            </section>
+          </div>
+        </main>
+      </div>
+
+      <TeamSelectionModal
+        isOpen={isTeamModalOpen}
+        onClose={() => setIsTeamModalOpen(false)}
+        onSelectTeam={handleTeamSelect}
+        currentTeamId={user.favoriteTeamId}
+      />
+      <AvatarModal
+        isOpen={isAvatarModalOpen}
+        onClose={() => setIsAvatarModalOpen(false)}
+        onSave={handleAvatarSave}
+        currentAvatar={user.avatarUrl}
+      />
+    </>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/StadiumModal.tsx
+++ b/the-scrum-book-nextjs/src/components/StadiumModal.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+import type { TeamInfo } from '@/types';
+import { XMarkIcon } from './Icons';
+
+interface StadiumModalProps {
+  team: TeamInfo | null;
+  onClose: () => void;
+}
+
+export const StadiumModal: React.FC<StadiumModalProps> = ({ team, onClose }) => {
+  if (!team) return null;
+
+  return (
+    <div 
+        className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4 backdrop-blur-sm" 
+        onClick={onClose} 
+        role="dialog" 
+        aria-modal="true" 
+        aria-labelledby="stadium-modal-title"
+    >
+      <div 
+        className="bg-surface rounded-xl shadow-lg w-full max-w-lg border border-border relative" 
+        onClick={e => e.stopPropagation()}
+      >
+        <button 
+            onClick={onClose} 
+            className="absolute top-3 right-3 p-1 rounded-full text-text-subtle hover:bg-surface-alt" 
+            aria-label="Close"
+        >
+          <XMarkIcon className="w-6 h-6" />
+        </button>
+        <div className="p-6">
+            <h2 id="stadium-modal-title" className="text-2xl font-bold text-primary">{team.stadium.name}</h2>
+            <p className="text-lg text-text-subtle mb-4">{team.name}</p>
+            <div className="space-y-3 text-text">
+                <p><span className="font-semibold text-text-strong w-24 inline-block">Location:</span> {team.location}</p>
+                <p><span className="font-semibold text-text-strong w-24 inline-block">Capacity:</span> {team.stadium.capacity}</p>
+                <p><span className="font-semibold text-text-strong w-24 inline-block">Established:</span> {team.established}</p>
+                <p className="pt-2 border-t border-border"><span className="font-semibold text-text-strong w-24 inline-block">Notes:</span> {team.stadium.notes}</p>
+            </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/StatsView.tsx
+++ b/the-scrum-book-nextjs/src/components/StatsView.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+
+import React, { useMemo, useState } from 'react';
+import type { AttendedMatch, User } from '@/types';
+import { TEAMS } from '@/services/mockData';
+import { TeamLogo } from './TeamLogo';
+import { ShareIcon, ShieldCheckIcon, UserCircleIcon } from './Icons';
+import { formatDateUK } from '@/utils/date';
+import { attemptShare, getAppShareUrl, type ShareOutcome } from '@/utils/share';
+
+interface StatsViewProps {
+    attendedMatches: AttendedMatch[];
+    user: User;
+}
+
+const StatCard: React.FC<{ label: string; children: React.ReactNode; className?: string }> = ({ label, children, className }) => (
+    <div className={`bg-surface p-4 rounded-xl shadow-card flex flex-col justify-center items-center text-center ${className}`}>
+        <div className="text-3xl md:text-4xl font-extrabold text-primary [font-variant-numeric:tabular-nums]">
+            {children}
+        </div>
+        <h3 className="text-xs font-semibold text-text-subtle uppercase mt-1">{label}</h3>
+    </div>
+);
+
+export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) => {
+
+    const stats = useMemo(() => {
+        if (attendedMatches.length === 0) {
+            return null;
+        }
+        
+        const currentYear = new Date().getFullYear();
+        const matchesThisSeason = attendedMatches.filter(am => new Date(am.match.startTime).getFullYear() === currentYear);
+
+        const uniqueVenues = new Set(attendedMatches.map(am => am.match.venue));
+        const uniqueVenuesThisSeason = new Set(matchesThisSeason.map(am => am.match.venue));
+
+        const teamCounts = attendedMatches.reduce((acc, { match }) => {
+            const home = match.homeTeam?.name || 'N/A';
+            const away = match.awayTeam?.name || 'N/A';
+            acc[home] = (acc[home] || 0) + 1;
+            acc[away] = (acc[away] || 0) + 1;
+            return acc;
+        }, {} as Record<string, number>);
+
+        const favoriteTeamEntry = Object.entries(teamCounts).sort((a, b) => b[1] - a[1])[0];
+        const favoriteTeam = favoriteTeamEntry ? Object.values(TEAMS).find(t => t.name === favoriteTeamEntry[0]) : null;
+
+        const totalPoints = attendedMatches.reduce((sum, am) => sum + am.match.scores.home + am.match.scores.away, 0);
+
+        const hasVisitedFrance = attendedMatches.some(am => am.match.homeTeam.name === 'Catalans Dragons' || am.match.awayTeam.name === 'Catalans Dragons');
+        const countryCount = hasVisitedFrance ? 2 : 1;
+
+        const highestScoringMatch = attendedMatches.reduce((highest, am) => {
+            const currentTotal = am.match.scores.home + am.match.scores.away;
+            const highestTotal = (highest?.match.scores.home || 0) + (highest?.match.scores.away || 0);
+            return currentTotal > highestTotal ? am : highest;
+        }, attendedMatches[0]);
+        
+        const bestMatchOfSeason = matchesThisSeason.length > 0
+            ? [...matchesThisSeason].sort((a, b) => new Date(b.match.startTime).getTime() - new Date(a.match.startTime).getTime())[0]
+            : null;
+
+        return {
+            totalMatches: attendedMatches.length,
+            totalPoints,
+            countryCount,
+            highestScoringMatch,
+            favoriteTeam: favoriteTeam || null,
+            favoriteTeamCount: favoriteTeamEntry ? favoriteTeamEntry[1] : 0,
+            bestMatchOfSeason,
+            totalGrounds: uniqueVenues.size,
+            newGroundsThisSeason: uniqueVenuesThisSeason.size,
+        };
+    }, [attendedMatches]);
+
+    const [shareFeedback, setShareFeedback] = useState<'idle' | ShareOutcome>('idle');
+
+    const handleShareStats = async () => {
+        if (!stats) return;
+
+        const shareUrl = getAppShareUrl();
+        const shareText = `I've logged ${stats.totalMatches} matches, ${stats.totalGrounds} grounds and ${stats.totalPoints} total points this season on The Scrum Book.`;
+
+        const outcome = await attemptShare({
+            title: `${user.name}'s rugby league stats`,
+            text: shareText,
+            url: shareUrl,
+            clipboardFallbackText: `${shareText} Keep up with me at ${shareUrl}`,
+        });
+
+        setShareFeedback(outcome);
+        setTimeout(() => setShareFeedback('idle'), 2500);
+    };
+
+    const renderShareFeedbackMessage = () => {
+        if (shareFeedback === 'copied') {
+            return 'Link copied!';
+        }
+        if (shareFeedback === 'shared') {
+            return 'Share sheet opened';
+        }
+        if (shareFeedback === 'failed') {
+            return 'Sharing unavailable';
+        }
+        return '';
+    };
+
+    if (!stats) {
+        return (
+            <div className="text-center py-20 bg-surface rounded-xl">
+                <h2 className="text-2xl font-bold text-text-strong">No Statistics Yet</h2>
+                <p className="text-text-subtle mt-2">Attend some matches to start building your personal stats dashboard!</p>
+            </div>
+        );
+    }
+
+    const shareFeedbackMessage = renderShareFeedbackMessage();
+
+    return (
+        <div className="space-y-6 text-text-strong">
+             <div className="flex justify-between items-center gap-3">
+                <h1 className="text-xl font-bold">The Scrum Book</h1>
+                <div className="flex flex-col items-end gap-1">
+                    <button
+                        type="button"
+                        onClick={handleShareStats}
+                        className="p-2 text-text-subtle hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
+                        aria-label="Share my stats"
+                    >
+                        <ShareIcon className="w-6 h-6"/>
+                    </button>
+                    {shareFeedbackMessage && (
+                        <span className="text-[11px] font-semibold text-text-subtle" role="status" aria-live="polite">
+                            {shareFeedbackMessage}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+                {user.avatarUrl ? (
+                    <img src={user.avatarUrl} alt="User avatar" className="w-20 h-20 rounded-full object-cover border-4 border-surface" />
+                ) : (
+                    <div className="w-20 h-20 rounded-full object-cover border-4 border-surface bg-surface-alt flex items-center justify-center">
+                        <UserCircleIcon className="w-12 h-12 text-text-subtle" />
+                    </div>
+                )}
+                <div>
+                    <h2 className="text-4xl font-extrabold text-primary">2024</h2>
+                    <p className="text-lg font-semibold text-text-strong">{user.name}</p>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+                <StatCard label="Matches">{stats.totalMatches}</StatCard>
+                <StatCard label="Total Points">{stats.totalPoints}</StatCard>
+                <StatCard label="Countries">{stats.countryCount}</StatCard>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="bg-surface p-4 rounded-xl shadow-card text-center">
+                    <h3 className="text-xs font-semibold text-text-subtle uppercase mb-2">Highest Scoring Match</h3>
+                    <div className="flex items-center justify-center gap-3">
+                        <ShieldCheckIcon className="w-8 h-8 text-text-subtle/50"/>
+                        <span className="text-2xl font-bold">{stats.highestScoringMatch.match.scores.home} - {stats.highestScoringMatch.match.scores.away}</span>
+                        <ShieldCheckIcon className="w-8 h-8 text-text-subtle/50"/>
+                    </div>
+                </div>
+                <div className="bg-surface p-4 rounded-xl shadow-card text-center flex flex-col justify-center">
+                    <h3 className="text-xs font-semibold text-text-subtle uppercase mb-2">Most Seen Team</h3>
+                    <div className="flex items-center justify-center gap-3">
+                       {stats.favoriteTeam && <TeamLogo teamId={stats.favoriteTeam.id} teamName={stats.favoriteTeam.name} size="small"/>}
+                        <span className="text-2xl font-bold">{stats.favoriteTeamCount}</span>
+                    </div>
+                </div>
+            </div>
+
+            {stats.bestMatchOfSeason && (
+                 <div className="bg-surface rounded-xl shadow-card overflow-hidden">
+                    <div className="relative">
+                        <img src="https://images.unsplash.com/photo-1594498742294-967252041133?q=80&w=2670&auto=format&fit=crop&ixlib-rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Stadium view" className="w-full h-32 object-cover"/>
+                        <div className="absolute inset-0 bg-black/40"></div>
+                        <h3 className="absolute top-2 left-4 text-white font-bold text-sm">BEST MATCH OF 2024</h3>
+                    </div>
+                    <div className="p-4">
+                        <p className="text-xs font-semibold text-text-subtle">{formatDateUK(stats.bestMatchOfSeason.match.startTime)}</p>
+                        <p className="font-bold">{stats.bestMatchOfSeason.match.venue}</p>
+                        <div className="flex items-center justify-between mt-2">
+                             <div className="flex items-center gap-2">
+                                <TeamLogo teamId={stats.bestMatchOfSeason.match.homeTeam.id} teamName={stats.bestMatchOfSeason.match.homeTeam.name} size="small"/>
+                                <span className="font-semibold text-sm">{stats.bestMatchOfSeason.match.homeTeam.name}</span>
+                            </div>
+                            <span className="font-bold text-lg">{stats.bestMatchOfSeason.match.scores.home}</span>
+                        </div>
+                        <div className="flex items-center justify-between mt-1">
+                             <div className="flex items-center gap-2">
+                                <TeamLogo teamId={stats.bestMatchOfSeason.match.awayTeam.id} teamName={stats.bestMatchOfSeason.match.awayTeam.name} size="small"/>
+                                <span className="font-semibold text-sm">{stats.bestMatchOfSeason.match.awayTeam.name}</span>
+                            </div>
+                            <span className="font-bold text-lg">{stats.bestMatchOfSeason.match.scores.away}</span>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <StatCard label="Grounds">{stats.totalGrounds}</StatCard>
+                <StatCard label="New Grounds (2024)">{stats.newGroundsThisSeason}</StatCard>
+            </div>
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/TeamLogo.tsx
+++ b/the-scrum-book-nextjs/src/components/TeamLogo.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import { TEAM_BRANDING } from '@/services/mockData';
+
+interface TeamLogoProps {
+  teamId: string;
+  teamName: string;
+  size?: 'small' | 'medium';
+  className?: string;
+}
+
+// Generates initials from the team name, taking the first letter of up to the first two words.
+const getInitials = (name: string): string => {
+    if (!name) return '?';
+    return name
+        .split(' ')
+        .map(word => word[0])
+        .slice(0, 2)
+        .join('')
+        .toUpperCase();
+};
+
+export const TeamLogo: React.FC<TeamLogoProps> = ({ teamId, teamName, size = 'medium', className = '' }) => {
+    const sizeClasses = {
+        small: 'w-6 h-6',
+        medium: 'w-10 h-10 md:w-12 md:h-12',
+    };
+
+    const textSizeClasses = {
+        small: 'text-[10px]',
+        medium: 'text-base md:text-lg',
+    };
+    
+    const initials = getInitials(teamName);
+    const branding = TEAM_BRANDING[teamId] || {
+        bg: '#6B7280',
+        text: '#FFFFFF',
+        palette: ['#6B7280', '#9CA3AF'],
+    }; // Default palette if no ID match
+    const palette = branding.palette ?? [branding.bg, branding.bg];
+    const background =
+        palette.length > 1
+            ? `linear-gradient(135deg, ${palette[0]}, ${palette[1]})`
+            : branding.bg;
+    const outline = palette.length > 2 ? palette[2] : 'rgba(255, 255, 255, 0.24)';
+
+    return (
+        <div
+            className={`rounded-full flex items-center justify-center overflow-hidden flex-shrink-0 ${sizeClasses[size]} ${className}`}
+            style={{
+                background,
+                boxShadow: `0 0 0 1px ${outline}`,
+            }}
+        >
+            <span
+                className={`font-bold select-none ${textSizeClasses[size]}`}
+                style={{ color: branding.text }}
+            >
+                {initials}
+            </span>
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/TeamSelectionModal.tsx
+++ b/the-scrum-book-nextjs/src/components/TeamSelectionModal.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { TEAMS, TEAM_BRANDING } from '@/services/mockData';
+import { TeamLogo } from './TeamLogo';
+import { XMarkIcon } from './Icons';
+
+interface TeamSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectTeam: (teamId: string) => void;
+  currentTeamId?: string;
+}
+
+const allTeams = Object.values(TEAMS);
+
+export const TeamSelectionModal: React.FC<TeamSelectionModalProps> = ({ isOpen, onClose, onSelectTeam, currentTeamId }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="team-select-title">
+      <div className="bg-surface rounded-xl shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h2 id="team-select-title" className="text-xl font-bold text-text-strong">Select Favorite Team</h2>
+          <button onClick={onClose} className="p-1 rounded-full text-text-subtle hover:bg-surface-alt" aria-label="Close">
+            <XMarkIcon className="w-6 h-6" />
+          </button>
+        </div>
+        <div className="p-6 overflow-y-auto">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {allTeams.map(team => {
+              const isSelected = currentTeamId === team.id;
+              const branding = TEAM_BRANDING[team.id];
+              const style = isSelected && branding ? { borderColor: branding.bg, backgroundColor: `${branding.bg}1A` } : {};
+
+              return (
+                <button 
+                  key={team.id}
+                  onClick={() => onSelectTeam(team.id)}
+                  className={`p-4 flex flex-col items-center gap-2 rounded-md transition-all border-2 ${
+                    !isSelected ? 'border-transparent hover:bg-surface-alt hover:shadow-md' : ''
+                  }`}
+                  style={style}
+                >
+                  <TeamLogo teamId={team.id} teamName={team.name} size="medium" />
+                  <span className="text-sm font-semibold text-center text-text-strong">{team.name}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/the-scrum-book-nextjs/src/components/TeamStatsView.tsx
+++ b/the-scrum-book-nextjs/src/components/TeamStatsView.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React, { useState } from 'react';
+import { teamsData } from '@/services/stadiumData';
+import type { TeamInfo } from '@/types';
+import { StadiumModal } from './StadiumModal';
+import { TrophyIcon } from './Icons';
+import { TeamLogo } from './TeamLogo';
+import { TEAMS, TEAM_BRANDING } from '@/services/mockData';
+
+export const TeamStatsView: React.FC = () => {
+    const [selectedTeam, setSelectedTeam] = useState<TeamInfo | null>(null);
+
+    return (
+        <div className="space-y-6">
+            <div className="text-center border-b border-border pb-4">
+                <h1 className="text-3xl font-bold text-text-strong">Rugby League Super League</h1>
+                <p className="text-lg text-text-subtle mt-1">Teams, Stats & Stadiums</p>
+            </div>
+
+            <main className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {teamsData.sort((a,b) => a.name.localeCompare(b.name)).map(team => {
+                    const teamDetails = Object.values(TEAMS).find(t => t.name === team.name);
+                    const branding = teamDetails ? TEAM_BRANDING[teamDetails.id] : null;
+
+                    return (
+                        <button
+                            key={team.name}
+                            onClick={() => setSelectedTeam(team)}
+                            className="bg-surface rounded-xl p-6 flex flex-col items-center text-center shadow-card hover:shadow-lg hover:-translate-y-1 transition-transform duration-200 overflow-hidden"
+                            style={branding ? { borderTop: `4px solid ${branding.bg}` } : {}}
+                        >
+                            <TeamLogo teamId={teamDetails?.id || ''} teamName={team.name} size="medium" className="mb-4" />
+                            <h2 className="text-xl font-bold mb-1 text-primary">{team.name}</h2>
+                            <p className="text-sm text-text-subtle mb-4">Established: {team.established}</p>
+                            <div className="mt-auto pt-4 text-text-strong border-t border-border w-full">
+                                <p className="text-base font-semibold flex items-center justify-center gap-2">
+                                    <TrophyIcon className="w-5 h-5 text-accent"/>
+                                    Super League Titles: <span className="text-text-strong">{team.titles}</span>
+                                </p>
+                                <p className="text-xs mt-2 text-text-subtle">{team.stadium.name}</p>
+                            </div>
+                        </button>
+                    )
+                })}
+            </main>
+
+            <StadiumModal team={selectedTeam} onClose={() => setSelectedTeam(null)} />
+        </div>
+    );
+};

--- a/the-scrum-book-nextjs/src/components/navigationItems.ts
+++ b/the-scrum-book-nextjs/src/components/navigationItems.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { View } from '@/types';
+import {
+  AboutIcon,
+  CommunityIcon,
+  FixturesResultsIcon,
+  GroundsIcon,
+  LeagueTableChartIcon,
+  NearbyIcon,
+  NextSevenDaysIcon,
+  UserCircleIcon,
+} from './Icons';
+
+export type NavigationItem = {
+  label: string;
+  view: View;
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+};
+
+export const mainNavigationItems: NavigationItem[] = [
+  { label: 'Profile', view: 'PROFILE', icon: UserCircleIcon },
+  { label: 'Next 7 Days', view: 'UPCOMING', icon: NextSevenDaysIcon },
+  { label: 'Nearby', view: 'NEARBY', icon: NearbyIcon },
+  { label: 'Fixtures & Results', view: 'MATCH_DAY', icon: FixturesResultsIcon },
+  { label: 'League Table', view: 'LEAGUE_TABLE', icon: LeagueTableChartIcon },
+  { label: 'Grounds', view: 'GROUNDS', icon: GroundsIcon },
+  { label: 'Community', view: 'COMMUNITY', icon: CommunityIcon },
+  { label: 'About', view: 'ABOUT', icon: AboutIcon },
+];

--- a/the-scrum-book-nextjs/src/contexts/AuthContext.tsx
+++ b/the-scrum-book-nextjs/src/contexts/AuthContext.tsx
@@ -1,0 +1,844 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, ReactNode, useMemo, useCallback } from 'react';
+import type {
+  User,
+  AttendedMatch,
+  Profile,
+  AuthUser,
+  Prediction,
+  SaveUserPredictionInput,
+} from '@/types';
+import { checkAndAwardBadges } from '@/badges';
+
+interface GoogleIdentityServices {
+  accounts: {
+    oauth2: {
+      initTokenClient: (config: {
+        client_id: string;
+        scope: string;
+        prompt?: string;
+        callback: (response: GoogleTokenResponse) => void;
+        error_callback?: (error: GoogleTokenErrorResponse) => void;
+      }) => GoogleTokenClient;
+    };
+  };
+}
+
+interface GoogleTokenClient {
+  requestAccessToken: (config?: { prompt?: string }) => void;
+}
+
+interface GoogleTokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+interface GoogleTokenErrorResponse {
+  error: string;
+  error_description?: string;
+}
+
+interface GoogleUserInfoResponse {
+  sub: string;
+  name?: string;
+  picture?: string;
+  email?: string;
+  given_name?: string;
+  family_name?: string;
+}
+
+declare global {
+  interface Window {
+    google?: GoogleIdentityServices;
+  }
+}
+
+interface AuthContextType {
+  currentUser: AuthUser | null;
+  profile: Profile | null;
+  loading: boolean;
+  login: () => Promise<void>;
+  loginWithCredentials: (identifier: string, password: string) => Promise<void>;
+  signup: (input: { name: string; email: string; password: string }) => Promise<void>;
+  requestPasswordReset: (identifier: string) => Promise<void>;
+  logout: () => Promise<void>;
+  addAttendedMatch: (match: AttendedMatch['match']) => Promise<void>;
+  removeAttendedMatch: (matchId: string) => Promise<void>;
+  updateUser: (user: Partial<User>) => Promise<void>;
+  addPhotoToMatch: (matchId: string, photoFile: File) => Promise<void>;
+  addFriend: (friendId: string) => Promise<void>;
+  removeFriend: (friendId: string) => Promise<void>;
+  saveUserPrediction: (input: SaveUserPredictionInput) => Promise<void>;
+  deleteUserPrediction: (matchId: string) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const LOCAL_PROFILE_KEY = 'scrum-book:profile';
+const LOCAL_AUTH_KEY = 'scrum-book:auth-user';
+const GOOGLE_IDENTITY_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+const LOCAL_ACCOUNTS_KEY = 'scrum-book:accounts';
+const LOCAL_PASSWORD_RESET_PREFIX = 'scrum-book:password-reset-requested';
+
+interface StoredAccount {
+  id: string;
+  identifier: string;
+  password: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  avatarUrl?: string;
+  avatarSource?: User['avatarSource'];
+  avatarUpdatedAt?: string;
+}
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const resolveAvatarSource = (overrides?: Partial<User>): User['avatarSource'] => {
+  if (overrides?.avatarSource) {
+    return overrides.avatarSource;
+  }
+  if (overrides?.avatarUrl) {
+    return 'google';
+  }
+  return 'generated';
+};
+
+const createEmptyProfile = (overrides?: Partial<User>): Profile => ({
+  user: {
+    name: overrides?.name ?? 'Guest',
+    favoriteTeamId: overrides?.favoriteTeamId,
+    avatarUrl: overrides?.avatarUrl,
+    avatarSource: resolveAvatarSource(overrides),
+    avatarUpdatedAt: overrides?.avatarUpdatedAt,
+  },
+  attendedMatches: [],
+  earnedBadgeIds: [],
+  friendIds: [],
+  predictions: [],
+});
+
+const mergeProfileDefaults = (profile: Partial<Profile> | null, userOverrides?: Partial<User>): Profile => {
+  const empty = createEmptyProfile(userOverrides);
+
+  if (!profile) {
+    return empty;
+  }
+
+  const storedUser: Partial<User> = profile.user ?? {};
+  const avatarMatchesOverride =
+    typeof storedUser.avatarUrl === 'string' && storedUser.avatarUrl === userOverrides?.avatarUrl;
+  const resolvedAvatarSource: User['avatarSource'] = storedUser.avatarSource
+    ? storedUser.avatarSource
+    : typeof storedUser.avatarUrl === 'string'
+    ? avatarMatchesOverride
+      ? empty.user.avatarSource
+      : 'custom'
+    : empty.user.avatarSource;
+  const resolvedAvatarUpdatedAt = storedUser.avatarUpdatedAt ?? (avatarMatchesOverride ? empty.user.avatarUpdatedAt : undefined);
+
+  return {
+    ...empty,
+    ...profile,
+    user: {
+      ...empty.user,
+      ...storedUser,
+      avatarSource: resolvedAvatarSource,
+      avatarUpdatedAt: resolvedAvatarUpdatedAt,
+    },
+    attendedMatches: profile.attendedMatches ?? [],
+    earnedBadgeIds: profile.earnedBadgeIds ?? [],
+    friendIds: profile.friendIds ?? [],
+    predictions: profile.predictions ?? [],
+  };
+};
+
+const getProfileStorageKey = (uid: string) => `${LOCAL_PROFILE_KEY}:${uid}`;
+
+const loadStoredProfile = (uid: string, userOverrides?: Partial<User>): Profile | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+  const raw = window.localStorage.getItem(getProfileStorageKey(uid));
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<Profile>;
+    return mergeProfileDefaults(parsed, userOverrides);
+  } catch (error) {
+    console.warn('Failed to parse stored profile. Resetting to defaults.', error);
+    window.localStorage.removeItem(getProfileStorageKey(uid));
+    return null;
+  }
+};
+
+const persistProfileForUser = (uid: string, profile: Profile) => {
+  if (!isBrowser()) {
+    return;
+  }
+  window.localStorage.setItem(getProfileStorageKey(uid), JSON.stringify(profile));
+};
+
+const ensureProfileForUser = (uid: string, overrides?: Partial<User>): Profile => {
+  const existing = loadStoredProfile(uid, overrides);
+  if (existing) {
+    persistProfileForUser(uid, existing);
+    return existing;
+  }
+  const fresh = createEmptyProfile(overrides);
+  persistProfileForUser(uid, fresh);
+  return fresh;
+};
+
+const readStoredAuthUser = (): AuthUser | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+  const raw = window.localStorage.getItem(LOCAL_AUTH_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as AuthUser;
+  } catch (error) {
+    console.warn('Failed to parse stored auth user. Clearing session.', error);
+    window.localStorage.removeItem(LOCAL_AUTH_KEY);
+    return null;
+  }
+};
+
+const persistAuthUser = (user: AuthUser | null) => {
+  if (!isBrowser()) {
+    return;
+  }
+  if (user) {
+    window.localStorage.setItem(LOCAL_AUTH_KEY, JSON.stringify(user));
+  } else {
+    window.localStorage.removeItem(LOCAL_AUTH_KEY);
+  }
+};
+
+const getDefaultUserDetails = (user: AuthUser | null): Partial<User> => {
+  const avatarSource: User['avatarSource'] = user?.avatarUrl ? 'google' : 'generated';
+
+  return {
+    name: user?.displayName || user?.email || 'Rugby Fan',
+    avatarUrl: user?.avatarUrl || undefined,
+    avatarSource,
+    avatarUpdatedAt: user?.avatarUrl ? new Date().toISOString() : undefined,
+  };
+};
+
+const normaliseIdentifier = (identifier: string) => identifier.trim().toLowerCase();
+
+const hashPassword = (password: string) => {
+  try {
+    if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+      return window.btoa(password);
+    }
+  } catch (error) {
+    console.warn('Falling back to deterministic password hashing.', error);
+  }
+  return Array.from(password)
+    .map((char) => char.charCodeAt(0).toString(16))
+    .join('-');
+};
+
+const loadStoredAccounts = (): StoredAccount[] => {
+  if (!isBrowser()) {
+    return [];
+  }
+  const raw = window.localStorage.getItem(LOCAL_ACCOUNTS_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredAccount[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored accounts. Clearing saved credentials.', error);
+    window.localStorage.removeItem(LOCAL_ACCOUNTS_KEY);
+    return [];
+  }
+};
+
+const persistStoredAccounts = (accounts: StoredAccount[]) => {
+  if (!isBrowser()) {
+    return;
+  }
+  window.localStorage.setItem(LOCAL_ACCOUNTS_KEY, JSON.stringify(accounts));
+};
+
+const createAccountId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `scrum-user-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const loadGoogleIdentityServices = async (): Promise<GoogleIdentityServices> => {
+  if (!isBrowser()) {
+    throw new Error('Google Sign-In requires a browser environment.');
+  }
+
+  if (window.google?.accounts?.oauth2) {
+    return window.google;
+  }
+
+  const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${GOOGLE_IDENTITY_SCRIPT_SRC}"]`);
+  if (existingScript && window.google?.accounts?.oauth2) {
+    return window.google;
+  }
+
+  const script = existingScript ?? document.createElement('script');
+  if (!existingScript) {
+    script.src = GOOGLE_IDENTITY_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    document.head.appendChild(script);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => reject(new Error('Failed to load Google Identity Services.')), { once: true });
+  });
+
+  if (!window.google?.accounts?.oauth2) {
+    throw new Error('Google Identity Services failed to initialise.');
+  }
+
+  return window.google;
+};
+
+const requestGoogleAccessToken = async (google: GoogleIdentityServices, clientId: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    try {
+      const tokenClient = google.accounts.oauth2.initTokenClient({
+        client_id: clientId,
+        scope: 'openid email profile',
+        callback: (response) => {
+          if (response.error) {
+            reject(new Error(response.error_description || 'Google sign-in was cancelled.'));
+            return;
+          }
+          if (!response.access_token) {
+            reject(new Error('Google did not return an access token.'));
+            return;
+          }
+          resolve(response.access_token);
+        },
+        error_callback: (error) => {
+          reject(new Error(error.error_description || error.error || 'Google sign-in failed.'));
+        },
+      });
+
+      tokenClient.requestAccessToken({ prompt: 'consent' });
+
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error('Failed to initialise Google sign-in.'));
+    }
+  });
+
+const fetchGoogleUserInfo = async (accessToken: string): Promise<GoogleUserInfoResponse> => {
+  const response = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Google profile information.');
+  }
+
+  return (await response.json()) as GoogleUserInfoResponse;
+};
+
+const readFileAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+const generatePredictionId = () => {
+  const cryptoRef = typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (cryptoRef?.randomUUID) {
+    return cryptoRef.randomUUID();
+  }
+  return `prediction-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const resolveAvatarUpdates = (
+  updates: Partial<User>
+): Partial<Pick<User, 'avatarSource' | 'avatarUpdatedAt'>> => {
+  const avatarChanges: Partial<Pick<User, 'avatarSource' | 'avatarUpdatedAt'>> = {};
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'avatarUrl')) {
+    const nextSource: User['avatarSource'] = updates.avatarUrl ? 'custom' : 'generated';
+    avatarChanges.avatarSource = nextSource;
+    avatarChanges.avatarUpdatedAt = updates.avatarUrl ? new Date().toISOString() : undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'avatarSource')) {
+    avatarChanges.avatarSource = updates.avatarSource;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'avatarUpdatedAt')) {
+    avatarChanges.avatarUpdatedAt = updates.avatarUpdatedAt;
+  }
+
+  return avatarChanges;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [currentUser, setCurrentUser] = useState<AuthUser | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [accounts, setAccounts] = useState<StoredAccount[]>(() => (isBrowser() ? loadStoredAccounts() : []));
+
+  const updateStoredAccounts = useCallback(
+    (updater: (previous: StoredAccount[]) => StoredAccount[]) => {
+      setAccounts((prev) => {
+        const next = updater(prev);
+        persistStoredAccounts(next);
+        return next;
+      });
+    },
+    []
+  );
+
+  const getAccountByIdentifier = useCallback(
+    (identifier: string) => {
+      const normalised = normaliseIdentifier(identifier);
+      return accounts.find((account) => account.identifier === normalised) ?? null;
+    },
+    [accounts]
+  );
+
+  const activeProfileStorageKey = useMemo(() => currentUser?.uid ?? 'offline-user', [currentUser?.uid]);
+
+  useEffect(() => {
+    const storedUser = readStoredAuthUser();
+    if (storedUser) {
+      setCurrentUser(storedUser);
+      const existingProfile = ensureProfileForUser(storedUser.uid, getDefaultUserDetails(storedUser));
+      setProfile(existingProfile);
+      setLoading(false);
+      return;
+    }
+
+    // Fallback to a guest profile so the app remains usable offline
+    const guestProfile = ensureProfileForUser('offline-user', { name: 'Guest' });
+    setProfile(guestProfile);
+    setLoading(false);
+  }, []);
+
+  const login = async () => {
+    setLoading(true);
+    try {
+      const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+      if (!clientId) {
+        throw new Error(
+          'Google Sign-In is not configured. Set the VITE_GOOGLE_CLIENT_ID environment variable to your OAuth client ID.'
+        );
+      }
+
+      const google = await loadGoogleIdentityServices();
+      const accessToken = await requestGoogleAccessToken(google, clientId);
+      const userInfo = await fetchGoogleUserInfo(accessToken);
+
+      const authUser: AuthUser = {
+        uid: userInfo.sub,
+        displayName: userInfo.name || userInfo.given_name || undefined,
+        avatarUrl: userInfo.picture || null,
+        email: userInfo.email || null,
+        isAnonymous: false,
+      };
+
+      persistAuthUser(authUser);
+      setCurrentUser(authUser);
+      const existingProfile = ensureProfileForUser(authUser.uid, getDefaultUserDetails(authUser));
+      const shouldSyncGoogleAvatar =
+        !!authUser.avatarUrl &&
+        existingProfile.user.avatarSource !== 'custom' &&
+        existingProfile.user.avatarUrl !== authUser.avatarUrl;
+
+      if (shouldSyncGoogleAvatar) {
+        const syncedProfile: Profile = {
+          ...existingProfile,
+          user: {
+            ...existingProfile.user,
+            avatarUrl: authUser.avatarUrl ?? undefined,
+            avatarSource: 'google',
+            avatarUpdatedAt: new Date().toISOString(),
+          },
+        };
+        setProfile(syncedProfile);
+        persistProfileForUser(authUser.uid, syncedProfile);
+      } else {
+        setProfile(existingProfile);
+      }
+    } catch (error) {
+      persistAuthUser(null);
+      setCurrentUser(null);
+      setProfile((prev) => prev ?? ensureProfileForUser('offline-user', { name: 'Guest' }));
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loginWithCredentials = async (identifier: string, password: string) => {
+    const trimmedIdentifier = identifier.trim();
+    if (!trimmedIdentifier) {
+      throw new Error('Please enter your email or phone number.');
+    }
+    if (!password) {
+      throw new Error('Please enter your password.');
+    }
+
+    setLoading(true);
+    try {
+      const account = getAccountByIdentifier(trimmedIdentifier);
+      if (!account) {
+        throw new Error('We couldn\'t find an account with those details.');
+      }
+      const hashedInput = hashPassword(password);
+      if (account.password !== hashedInput) {
+        throw new Error('Incorrect password. Please try again.');
+      }
+
+      updateStoredAccounts((prev) =>
+        prev.map((existing) =>
+          existing.id === account.id
+            ? { ...existing, updatedAt: new Date().toISOString() }
+            : existing
+        )
+      );
+
+      const authUser: AuthUser = {
+        uid: account.id,
+        displayName: account.name,
+        email: account.identifier.includes('@') ? account.identifier : null,
+        isAnonymous: false,
+        avatarUrl: account.avatarUrl ?? null,
+      };
+
+      persistAuthUser(authUser);
+      setCurrentUser(authUser);
+      const existingProfile = ensureProfileForUser(authUser.uid, {
+        name: account.name,
+        avatarUrl: account.avatarUrl,
+        avatarSource: account.avatarSource,
+        avatarUpdatedAt: account.avatarUpdatedAt,
+      });
+      setProfile(existingProfile);
+    } catch (error) {
+      setProfile((prev) => prev ?? ensureProfileForUser('offline-user', { name: 'Guest' }));
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const signup = async (input: { name: string; email: string; password: string }) => {
+    const name = input.name.trim();
+    const email = input.email.trim();
+    if (!name) {
+      throw new Error('Please tell us your name.');
+    }
+    if (!email) {
+      throw new Error('Email is required to create an account.');
+    }
+    if (input.password.length < 6) {
+      throw new Error('Passwords need to be at least 6 characters long.');
+    }
+
+    const identifier = normaliseIdentifier(email);
+    if (getAccountByIdentifier(identifier)) {
+      throw new Error('An account already exists with that email address.');
+    }
+
+    setLoading(true);
+    try {
+      const now = new Date().toISOString();
+      const account: StoredAccount = {
+        id: createAccountId(),
+        identifier,
+        password: hashPassword(input.password),
+        name,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      updateStoredAccounts((prev) => [...prev, account]);
+
+      const authUser: AuthUser = {
+        uid: account.id,
+        displayName: name,
+        email: identifier.includes('@') ? identifier : null,
+        isAnonymous: false,
+        avatarUrl: account.avatarUrl ?? null,
+      };
+
+      persistAuthUser(authUser);
+      setCurrentUser(authUser);
+      const newProfile = ensureProfileForUser(authUser.uid, {
+        name,
+        avatarUrl: account.avatarUrl,
+        avatarSource: account.avatarSource,
+        avatarUpdatedAt: account.avatarUpdatedAt,
+      });
+      setProfile(newProfile);
+    } catch (error) {
+      setProfile((prev) => prev ?? ensureProfileForUser('offline-user', { name: 'Guest' }));
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const requestPasswordReset = async (identifier: string) => {
+    const trimmed = identifier.trim();
+    if (!trimmed) {
+      throw new Error('Enter the email associated with your account.');
+    }
+
+    const account = getAccountByIdentifier(trimmed);
+    if (!account) {
+      throw new Error('We couldn\'t find an account with that email.');
+    }
+
+    if (isBrowser()) {
+      const storageKey = `${LOCAL_PASSWORD_RESET_PREFIX}:${account.id}`;
+      window.localStorage.setItem(storageKey, new Date().toISOString());
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+  };
+
+  const logout = async () => {
+    setLoading(true);
+    persistAuthUser(null);
+    setCurrentUser(null);
+    const guestProfile = ensureProfileForUser('offline-user', { name: 'Guest' });
+    setProfile(guestProfile);
+    setLoading(false);
+  };
+
+  const addAttendedMatch = async (match: AttendedMatch['match']) => {
+    if (!profile) {
+      return;
+    }
+
+    const newAttendedMatch: AttendedMatch = {
+      match,
+      attendedOn: new Date().toISOString(),
+    };
+
+    const updatedMatches = [...(profile.attendedMatches || []), newAttendedMatch];
+    const newlyEarnedBadges = checkAndAwardBadges(updatedMatches, profile.earnedBadgeIds || [], profile.user);
+    const updatedBadgeIds = [...(profile.earnedBadgeIds || []), ...newlyEarnedBadges];
+    const nextProfile: Profile = { ...profile, attendedMatches: updatedMatches, earnedBadgeIds: updatedBadgeIds };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const removeAttendedMatch = async (matchId: string) => {
+    if (!profile) return;
+
+    const updatedMatches = (profile.attendedMatches || []).filter((am) => am.match.id !== matchId);
+    const nextProfile: Profile = { ...profile, attendedMatches: updatedMatches };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const updateUser = async (updatedUser: Partial<User>) => {
+    if (!profile) return;
+
+    const avatarFields = resolveAvatarUpdates(updatedUser);
+
+    const newProfileUser: User = { ...profile.user, ...updatedUser, ...avatarFields };
+    const nextProfile: Profile = { ...profile, user: newProfileUser };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+
+    if (currentUser) {
+      let shouldPersistAuthUser = false;
+      let nextAuthUser: AuthUser = currentUser;
+      const accountChanges: Partial<StoredAccount> = {};
+      let hasAccountChanges = false;
+
+      if (Object.prototype.hasOwnProperty.call(updatedUser, 'avatarUrl')) {
+        nextAuthUser = { ...nextAuthUser, avatarUrl: updatedUser.avatarUrl ?? null };
+        shouldPersistAuthUser = true;
+        accountChanges.avatarUrl = updatedUser.avatarUrl ?? undefined;
+        accountChanges.avatarSource = newProfileUser.avatarSource;
+        accountChanges.avatarUpdatedAt = newProfileUser.avatarUpdatedAt;
+        hasAccountChanges = true;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(updatedUser, 'avatarSource')) {
+        accountChanges.avatarSource = newProfileUser.avatarSource;
+        hasAccountChanges = true;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(updatedUser, 'avatarUpdatedAt')) {
+        accountChanges.avatarUpdatedAt = newProfileUser.avatarUpdatedAt;
+        hasAccountChanges = true;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(updatedUser, 'name')) {
+        nextAuthUser = { ...nextAuthUser, displayName: newProfileUser.name };
+        shouldPersistAuthUser = true;
+        accountChanges.name = newProfileUser.name;
+        hasAccountChanges = true;
+      }
+
+      if (hasAccountChanges) {
+        updateStoredAccounts((prev) =>
+          prev.map((account) =>
+            account.id === currentUser.uid
+              ? { ...account, ...accountChanges, updatedAt: new Date().toISOString() }
+              : account
+          )
+        );
+      }
+
+      if (shouldPersistAuthUser) {
+        setCurrentUser(nextAuthUser);
+        persistAuthUser(nextAuthUser);
+      }
+    }
+  };
+
+  const addPhotoToMatch = async (matchId: string, photoFile: File) => {
+    if (!profile) return;
+
+    try {
+      const photoUrl = await readFileAsDataUrl(photoFile);
+      const updatedMatches = (profile.attendedMatches || []).map((am) =>
+        am.match.id === matchId ? { ...am, photoUrl } : am
+      );
+      const nextProfile: Profile = { ...profile, attendedMatches: updatedMatches };
+      setProfile(nextProfile);
+      persistProfileForUser(activeProfileStorageKey, nextProfile);
+    } catch (error) {
+      console.error('Failed to process photo offline:', error);
+    }
+  };
+
+  const addFriend = async (friendId: string) => {
+    if (!profile) return;
+    if (profile.friendIds.includes(friendId)) {
+      return;
+    }
+
+    const updatedFriendIds = [...profile.friendIds, friendId];
+    const nextProfile: Profile = { ...profile, friendIds: updatedFriendIds };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const removeFriend = async (friendId: string) => {
+    if (!profile) return;
+    const updatedFriendIds = profile.friendIds.filter((id) => id !== friendId);
+    const nextProfile: Profile = { ...profile, friendIds: updatedFriendIds };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const saveUserPrediction = async (input: SaveUserPredictionInput) => {
+    if (!profile) return;
+
+    const timestamp = new Date().toISOString();
+    const existingIndex = profile.predictions.findIndex((prediction) => prediction.matchId === input.matchId);
+
+    let updatedPredictions: Prediction[];
+
+    if (existingIndex >= 0) {
+      const existingPrediction = profile.predictions[existingIndex];
+      updatedPredictions = [...profile.predictions];
+      updatedPredictions[existingIndex] = {
+        ...existingPrediction,
+        outcome: input.outcome,
+        confidence: input.confidence ?? existingPrediction.confidence,
+        notes: input.notes,
+        updatedAt: timestamp,
+      };
+    } else {
+      const newPrediction: Prediction = {
+        id: generatePredictionId(),
+        matchId: input.matchId,
+        outcome: input.outcome,
+        confidence: input.confidence,
+        notes: input.notes,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      updatedPredictions = [...profile.predictions, newPrediction];
+    }
+
+    const nextProfile: Profile = { ...profile, predictions: updatedPredictions };
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const deleteUserPrediction = async (matchId: string) => {
+    if (!profile) return;
+
+    const updatedPredictions = profile.predictions.filter((prediction) => prediction.matchId !== matchId);
+    const nextProfile: Profile = { ...profile, predictions: updatedPredictions };
+
+    setProfile(nextProfile);
+    persistProfileForUser(activeProfileStorageKey, nextProfile);
+  };
+
+  const value = {
+    currentUser,
+    profile,
+    loading,
+    login,
+    loginWithCredentials,
+    signup,
+    requestPasswordReset,
+    logout,
+    addAttendedMatch,
+    removeAttendedMatch,
+    updateUser,
+    addPhotoToMatch,
+    addFriend,
+    removeFriend,
+    saveUserPrediction,
+    deleteUserPrediction,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/the-scrum-book-nextjs/src/hooks/useGeolocation.ts
+++ b/the-scrum-book-nextjs/src/hooks/useGeolocation.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+type Position = {
+    lat: number;
+    lon: number;
+};
+
+type GeolocationError = {
+    code: number;
+    message: string;
+};
+
+export const useGeolocation = () => {
+    const [position, setPosition] = useState<Position | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<GeolocationError | null>(null);
+
+    const requestLocation = useCallback(() => {
+        setIsLoading(true);
+        setError(null);
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(
+                (pos) => {
+                    setPosition({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+                    setIsLoading(false);
+                },
+                (err) => {
+                    setError({ code: err.code, message: err.message });
+                    setIsLoading(false);
+                },
+                { timeout: 10000, enableHighAccuracy: true }
+            );
+        } else {
+            setError({ code: 0, message: "Geolocation is not supported by this browser." });
+            setIsLoading(false);
+        }
+    }, []);
+
+    return { position, isLoading, error, requestLocation };
+};

--- a/the-scrum-book-nextjs/src/hooks/useLocalStorage.ts
+++ b/the-scrum-book-nextjs/src/hooks/useLocalStorage.ts
@@ -1,0 +1,39 @@
+'use client';
+
+
+import { useState, useEffect } from 'react';
+
+export const useLocalStorage = <T,>(key: string, initialValue: T): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.error(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+     try {
+        const item = window.localStorage.getItem(key);
+        if (item) {
+            setStoredValue(JSON.parse(item));
+        }
+     } catch (error) {
+        console.error(error)
+     }
+  }, [key]);
+
+  return [storedValue, setValue];
+};

--- a/the-scrum-book-nextjs/src/hooks/useTheme.ts
+++ b/the-scrum-book-nextjs/src/hooks/useTheme.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+
+export const useTheme = (): [string, () => void] => {
+  // Default to dark, but the user's preference in localStorage will override it.
+  const [theme, setTheme] = useLocalStorage<string>('theme', 'dark');
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const isDark = theme === 'dark';
+    
+    root.classList.remove(isDark ? 'light' : 'dark');
+    root.classList.add(theme);
+
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  return [theme, toggleTheme];
+};

--- a/the-scrum-book-nextjs/src/services/apiService.ts
+++ b/the-scrum-book-nextjs/src/services/apiService.ts
@@ -1,0 +1,34 @@
+import type { Match, LeagueStanding } from '@/types';
+import { mockMatches, mockLeagueTable } from './mockData';
+
+const logOfflineFallback = (collection: string) => {
+  console.info(`Using local mock data for ${collection}.`);
+};
+
+export const fetchMatches = async (): Promise<Match[]> => {
+  try {
+    const response = await fetch('http://localhost:3001/api/matches');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch matches: ${response.statusText}`);
+    }
+
+    return (await response.json()) as Match[];
+  } catch (error) {
+    logOfflineFallback('matches');
+    return mockMatches;
+  }
+};
+
+export const fetchLeagueTable = async (): Promise<LeagueStanding[]> => {
+  try {
+    const response = await fetch('http://localhost:3001/api/league-table');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch league table: ${response.statusText}`);
+    }
+
+    return (await response.json()) as LeagueStanding[];
+  } catch (error) {
+    logOfflineFallback('league table');
+    return mockLeagueTable;
+  }
+};

--- a/the-scrum-book-nextjs/src/services/mockData.ts
+++ b/the-scrum-book-nextjs/src/services/mockData.ts
@@ -1,0 +1,460 @@
+// fixtures.ts
+
+import type { Match, LeagueStanding, Team, Venue } from 'types';
+
+// ---------- Teams ----------
+export const TEAMS = {
+  wigan: { id: '1', name: 'Wigan Warriors', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/z328jy1600893040.png' },
+  stHelens: { id: '2', name: 'St Helens', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/qsw4741599320017.png' },
+  leeds: { id: '3', name: 'Leeds Rhinos', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/p14u931599320349.png' },
+  warrington: { id: '4', name: 'Warrington Wolves', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/6990ay1599320138.png' },
+  catalans: { id: '5', name: 'Catalans Dragons', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/19k0uq1599320256.png' },
+  huddersfield: { id: '6', name: 'Huddersfield Giants', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/yt8cfx1599320478.png' },
+  hullKR: { id: '7', name: 'Hull KR', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/u0ypre1599320577.png' },
+  hullFC: { id: '8', name: 'Hull FC', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/34tppc1599320649.png' },
+  salford: { id: '9', name: 'Salford Red Devils', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/mvx62g1599320875.png' },
+  leigh: { id: '10', name: 'Leigh Leopards', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/b5z9g31671732681.png' },
+  castleford: { id: '11', name: 'Castleford Tigers', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/8iif5k1599320790.png' },
+  london: { id: '12', name: 'London Broncos', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/3k75b41600892790.png' },
+  wakefield: { id: '13', name: 'Wakefield Trinity', logoUrl: 'https://www.thesportsdb.com/images/media/team/badge/en323k1599320716.png' }
+} as const;
+
+const TEAM_NAME_LOOKUP: Record<string, Team> = Object.values(TEAMS).reduce(
+  (accumulator, team) => {
+    accumulator[team.name] = team;
+    return accumulator;
+  },
+  {} as Record<string, Team>
+);
+
+const WINNER_SF1: Team = { id: 'winner-sf1', name: 'TBC (Winner SF1)', logoUrl: '' };
+const WINNER_SF2: Team = { id: 'winner-sf2', name: 'TBC (Winner SF2)', logoUrl: '' };
+
+// ---------- Team branding ----------
+export interface TeamBranding {
+  bg: string;
+  text: string;
+  palette: string[];
+}
+
+export const TEAM_BRANDING: Record<string, TeamBranding> = {
+  '1': { bg: '#862633', text: '#FFFFFF', palette: ['#862633', '#FFFFFF', '#060805'] },
+  '2': { bg: '#B31F1D', text: '#FFFFFF', palette: ['#B31F1D', '#FFFFFF'] },
+  '3': { bg: '#00539F', text: '#FFFFFF', palette: ['#00539F', '#FFB81C'] },
+  '4': { bg: '#015DAA', text: '#FFFFFF', palette: ['#015DAA', '#FFD700', '#FFFFFF'] },
+  '5': { bg: '#E62228', text: '#FFFFFF', palette: ['#E62228', '#FFD700', '#FFFFFF'] },
+  '6': { bg: '#8A0035', text: '#FFFFFF', palette: ['#8A0035', '#FFB81C'] },
+  '7': { bg: '#E6002A', text: '#FFFFFF', palette: ['#E6002A', '#FFFFFF'] },
+  '8': { bg: '#000000', text: '#FFFFFF', palette: ['#000000', '#FFFFFF'] },
+  '9': { bg: '#DA291C', text: '#FFFFFF', palette: ['#DA291C', '#FFFFFF', '#000000'] },
+  '10': { bg: '#000000', text: '#FFFFFF', palette: ['#000000', '#FFFFFF', '#D4AF37'] },
+  '11': { bg: '#F47C10', text: '#000000', palette: ['#F47C10', '#000000'] },
+  '12': { bg: '#000000', text: '#FFFFFF', palette: ['#000000', '#E4032C', '#FFFFFF'] },
+  '13': { bg: '#0073C0', text: '#FFFFFF', palette: ['#0073C0', '#FFFFFF', '#D71920'] }
+};
+
+// ---------- Venues ----------
+const VENUES = {
+  dw: 'The Brick Community Stadium',
+  totallyWicked: 'Totally Wicked Stadium',
+  headingley: 'Headingley',
+  halliwellJones: 'Halliwell Jones Stadium',
+  gilbertBrutus: 'Stade Gilbert Brutus',
+  johnSmiths: "John Smith's Stadium",
+  cravenPark: 'Sewell Group Craven Park',
+  mkm: 'MKM Stadium',
+  salfordCommunity: 'Salford Community Stadium',
+  leighSportsVillage: 'Leigh Sports Village',
+  mendAHose: 'Mend-A-Hose Jungle',
+  cherryRed: 'Cherry Red Records Stadium',
+  belleVue: 'Belle Vue',
+  oldTrafford: 'Old Trafford',
+  stJamesPark: "St James' Park"
+} as const;
+
+export const teamIdToVenue: Record<string, string> = {
+  [TEAMS.wigan.id]: VENUES.dw,
+  [TEAMS.stHelens.id]: VENUES.totallyWicked,
+  [TEAMS.leeds.id]: VENUES.headingley,
+  [TEAMS.warrington.id]: VENUES.halliwellJones,
+  [TEAMS.catalans.id]: VENUES.gilbertBrutus,
+  [TEAMS.huddersfield.id]: VENUES.johnSmiths,
+  [TEAMS.hullKR.id]: VENUES.cravenPark,
+  [TEAMS.hullFC.id]: VENUES.mkm,
+  [TEAMS.salford.id]: VENUES.salfordCommunity,
+  [TEAMS.leigh.id]: VENUES.leighSportsVillage,
+  [TEAMS.castleford.id]: VENUES.mendAHose,
+  [TEAMS.london.id]: VENUES.cherryRed,
+  [TEAMS.wakefield.id]: VENUES.belleVue
+};
+
+// If your Venue type makes x and y optional, this matches your data below.
+// If not, add x and y to the neutral venues too.
+export const ALL_VENUES: Venue[] = [
+  { name: VENUES.dw, team: TEAMS.wigan.name, lat: 53.547, lon: -2.651, x: 245, y: 300 },
+  { name: VENUES.totallyWicked, team: TEAMS.stHelens.name, lat: 53.453, lon: -2.729, x: 235, y: 310 },
+  { name: VENUES.headingley, team: TEAMS.leeds.name, lat: 53.816, lon: -1.583, x: 280, y: 285 },
+  { name: VENUES.halliwellJones, team: TEAMS.warrington.name, lat: 53.393, lon: -2.583, x: 250, y: 320 },
+  { name: VENUES.gilbertBrutus, team: TEAMS.catalans.name, lat: 42.716, lon: 2.894, x: 450, y: 750 },
+  { name: VENUES.johnSmiths, team: TEAMS.huddersfield.name, lat: 53.655, lon: -1.768, x: 275, y: 295 },
+  { name: VENUES.cravenPark, team: TEAMS.hullKR.name, lat: 53.75, lon: -0.298, x: 335, y: 280 },
+  { name: VENUES.mkm, team: TEAMS.hullFC.name, lat: 53.746, lon: -0.367, x: 330, y: 285 },
+  { name: VENUES.salfordCommunity, team: TEAMS.salford.name, lat: 53.468, lon: -2.359, x: 255, y: 310 },
+  { name: VENUES.leighSportsVillage, team: TEAMS.leigh.name, lat: 53.492, lon: -2.528, x: 240, y: 305 },
+  { name: VENUES.mendAHose, team: TEAMS.castleford.name, lat: 53.719, lon: -1.336, x: 290, y: 290 },
+  { name: VENUES.cherryRed, team: TEAMS.london.name, lat: 51.431, lon: -0.188, x: 320, y: 640 },
+  { name: VENUES.belleVue, team: TEAMS.wakefield.name, lat: 53.673, lon: -1.481, x: 285, y: 292 },
+  { name: VENUES.oldTrafford, team: 'Neutral', lat: 53.4631, lon: -2.2913 },
+  { name: VENUES.stJamesPark, team: 'Neutral', lat: 54.9756, lon: -1.6218 }
+];
+
+export const VENUE_LOCATIONS: Record<string, { x: number; y: number; name: string }> = {
+  [VENUES.dw]: { x: 245, y: 300, name: VENUES.dw },
+  [VENUES.totallyWicked]: { x: 235, y: 310, name: VENUES.totallyWicked },
+  [VENUES.headingley]: { x: 280, y: 285, name: VENUES.headingley },
+  [VENUES.halliwellJones]: { x: 250, y: 320, name: VENUES.halliwellJones },
+  [VENUES.gilbertBrutus]: { x: 450, y: 750, name: VENUES.gilbertBrutus },
+  [VENUES.johnSmiths]: { x: 275, y: 295, name: VENUES.johnSmiths },
+  [VENUES.cravenPark]: { x: 335, y: 280, name: VENUES.cravenPark },
+  [VENUES.mkm]: { x: 330, y: 285, name: VENUES.mkm },
+  [VENUES.salfordCommunity]: { x: 255, y: 310, name: VENUES.salfordCommunity },
+  [VENUES.leighSportsVillage]: { x: 240, y: 305, name: VENUES.leighSportsVillage },
+  [VENUES.mendAHose]: { x: 290, y: 290, name: VENUES.mendAHose },
+  [VENUES.cherryRed]: { x: 320, y: 640, name: VENUES.cherryRed },
+  [VENUES.belleVue]: { x: 285, y: 292, name: VENUES.belleVue },
+  [VENUES.oldTrafford]: { x: 260, y: 315, name: VENUES.oldTrafford },
+  [VENUES.stJamesPark]: { x: 280, y: 150, name: VENUES.stJamesPark }
+};
+
+// ---------- Match factory helpers ----------
+const createMatch = (
+  id: number,
+  homeTeam: Team,
+  awayTeam: Team,
+  status: Match['status'],
+  daysOffset: number,
+  homeScore: number,
+  awayScore: number,
+  venue: string
+): Match => {
+  const date = new Date();
+  date.setDate(date.getDate() + daysOffset);
+  date.setHours(19, 45, 0, 0);
+
+  return {
+    id: `mock-${id}`,
+    competition: { id: '4415', name: 'Betfred Super League' },
+    homeTeam,
+    awayTeam,
+    status,
+    startTime: date.toISOString(),
+    venue,
+    scores: { home: homeScore, away: awayScore },
+    stats:
+      status === 'FULL-TIME'
+        ? {
+            possession: {
+              home: 50 + Math.floor(Math.random() * 10) - 5,
+              away: 50 + Math.floor(Math.random() * 10) - 5
+            },
+            territory: {
+              home: 50 + Math.floor(Math.random() * 10) - 5,
+              away: 50 + Math.floor(Math.random() * 10) - 5
+            },
+            tackles: {
+              home: 300 + Math.floor(Math.random() * 50),
+              away: 300 + Math.floor(Math.random() * 50)
+            }
+          }
+        : undefined
+  };
+};
+
+const createMatchOnDate = (
+  id: number,
+  homeTeam: Team,
+  awayTeam: Team,
+  status: Match['status'],
+  date: Date,
+  homeScore: number,
+  awayScore: number,
+  venue: string
+): Match => {
+  return {
+    id: `mock-${id}`,
+    competition: { id: '4415', name: 'Betfred Super League' },
+    homeTeam,
+    awayTeam,
+    status,
+    startTime: date.toISOString(),
+    venue,
+    scores: { home: homeScore, away: awayScore },
+    stats:
+      status === 'FULL-TIME'
+        ? {
+            possession: {
+              home: 50 + Math.floor(Math.random() * 10) - 5,
+              away: 50 + Math.floor(Math.random() * 10) - 5
+            },
+            territory: {
+              home: 50 + Math.floor(Math.random() * 10) - 5,
+              away: 50 + Math.floor(Math.random() * 10) - 5
+            },
+            tackles: {
+              home: 300 + Math.floor(Math.random() * 50),
+              away: 300 + Math.floor(Math.random() * 50)
+            }
+          }
+        : undefined
+  };
+};
+
+type RawResult = {
+  date: string;
+  home_team: string;
+  away_team: string;
+  home_score: number;
+  away_score: number;
+};
+
+const createKickoffDate = (dateString: string, index: number): Date => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  const slot = index % 4;
+  return new Date(Date.UTC(year, month - 1, day, 12 + slot * 2, 0, 0));
+};
+
+const RAW_2025_RESULTS: RawResult[] = [
+  { date: '2025-10-03', home_team: 'Wigan Warriors', away_team: 'Leigh Leopards', home_score: 18, away_score: 6 },
+  { date: '2025-09-27', home_team: 'Leeds Rhinos', away_team: 'St Helens', home_score: 14, away_score: 16 },
+  { date: '2025-09-26', home_team: 'Leigh Leopards', away_team: 'Wakefield Trinity', home_score: 26, away_score: 10 },
+  { date: '2025-09-19', home_team: 'Leigh Leopards', away_team: 'Huddersfield Giants', home_score: 30, away_score: 16 },
+  { date: '2025-09-19', home_team: 'St Helens', away_team: 'Castleford Tigers', home_score: 26, away_score: 24 },
+  { date: '2025-09-19', home_team: 'Salford Red Devils', away_team: 'Wakefield Trinity', home_score: 16, away_score: 52 },
+  { date: '2025-09-19', home_team: 'Wigan Warriors', away_team: 'Leeds Rhinos', home_score: 22, away_score: 6 },
+  { date: '2025-09-18', home_team: 'Hull FC', away_team: 'Catalans Dragons', home_score: 22, away_score: 26 },
+  { date: '2025-09-18', home_team: 'Hull KR', away_team: 'Warrington Wolves', home_score: 28, away_score: 20 },
+  { date: '2025-09-14', home_team: 'Huddersfield Giants', away_team: 'Salford Red Devils', home_score: 22, away_score: 8 },
+  { date: '2025-09-13', home_team: 'Wakefield Trinity', away_team: 'Hull KR', home_score: 28, away_score: 12 },
+  { date: '2025-09-13', home_team: 'Hull FC', away_team: 'Warrington Wolves', home_score: 34, away_score: 2 },
+  { date: '2025-09-12', home_team: 'Leigh Leopards', away_team: 'St Helens', home_score: 28, away_score: 10 },
+  { date: '2025-09-12', home_team: 'Wigan Warriors', away_team: 'Castleford Tigers', home_score: 62, away_score: 6 },
+  { date: '2025-09-11', home_team: 'Leeds Rhinos', away_team: 'Catalans Dragons', home_score: 8, away_score: 16 },
+  { date: '2025-09-07', home_team: 'Hull KR', away_team: 'Hull FC', home_score: 18, away_score: 4 },
+  { date: '2025-09-06', home_team: 'Warrington Wolves', away_team: 'Leigh Leopards', home_score: 12, away_score: 34 },
+  { date: '2025-09-05', home_team: 'St Helens', away_team: 'Wigan Warriors', home_score: 4, away_score: 18 },
+  { date: '2025-09-05', home_team: 'Castleford Tigers', away_team: 'Wakefield Trinity', home_score: 26, away_score: 22 },
+  { date: '2025-09-04', home_team: 'Salford Red Devils', away_team: 'Catalans Dragons', home_score: 16, away_score: 17 },
+  { date: '2025-09-04', home_team: 'Huddersfield Giants', away_team: 'Leeds Rhinos', home_score: 0, away_score: 26 },
+  { date: '2025-08-30', home_team: 'Catalans Dragons', away_team: 'Wigan Warriors', home_score: 4, away_score: 40 },
+  { date: '2025-08-30', home_team: 'Wakefield Trinity', away_team: 'Huddersfield Giants', home_score: 48, away_score: 2 },
+  { date: '2025-08-30', home_team: 'Hull FC', away_team: 'Leeds Rhinos', home_score: 0, away_score: 34 },
+  { date: '2025-08-29', home_team: 'Warrington Wolves', away_team: 'Salford Red Devils', home_score: 12, away_score: 25 },
+  { date: '2025-08-29', home_team: 'Hull KR', away_team: 'St Helens', home_score: 12, away_score: 8 },
+  { date: '2025-08-28', home_team: 'Leigh Leopards', away_team: 'Castleford Tigers', home_score: 46, away_score: 6 },
+  { date: '2025-08-24', home_team: 'Huddersfield Giants', away_team: 'Warrington Wolves', home_score: 23, away_score: 10 },
+  { date: '2025-08-24', home_team: 'Wigan Warriors', away_team: 'Wakefield Trinity', home_score: 44, away_score: 2 },
+  { date: '2025-08-23', home_team: 'Catalans Dragons', away_team: 'Castleford Tigers', home_score: 38, away_score: 4 },
+  { date: '2025-08-22', home_team: 'Leigh Leopards', away_team: 'Salford Red Devils', home_score: 38, away_score: 6 },
+  { date: '2025-08-22', home_team: 'St Helens', away_team: 'Hull FC', home_score: 16, away_score: 10 },
+  { date: '2025-08-21', home_team: 'Leeds Rhinos', away_team: 'Hull KR', home_score: 28, away_score: 6 },
+  { date: '2025-08-17', home_team: 'Salford Red Devils', away_team: 'Wakefield Trinity', home_score: 0, away_score: 48 },
+  { date: '2025-08-17', home_team: 'St Helens', away_team: 'Huddersfield Giants', home_score: 52, away_score: 4 },
+  { date: '2025-08-16', home_team: 'Hull FC', away_team: 'Leigh Leopards', home_score: 18, away_score: 12 },
+  { date: '2025-08-16', home_team: 'Castleford Tigers', away_team: 'Leeds Rhinos', home_score: 6, away_score: 64 },
+  { date: '2025-08-15', home_team: 'Wigan Warriors', away_team: 'Hull KR', home_score: 6, away_score: 10 },
+  { date: '2025-08-14', home_team: 'Warrington Wolves', away_team: 'Catalans Dragons', home_score: 30, away_score: 22 },
+  { date: '2025-08-10', home_team: 'Hull FC', away_team: 'Salford Red Devils', home_score: 80, away_score: 6 },
+  { date: '2025-08-09', home_team: 'Huddersfield Giants', away_team: 'Catalans Dragons', home_score: 18, away_score: 6 },
+  { date: '2025-08-09', home_team: 'Hull KR', away_team: 'Castleford Tigers', home_score: 36, away_score: 6 },
+  { date: '2025-08-08', home_team: 'Wakefield Trinity', away_team: 'St Helens', home_score: 4, away_score: 34 },
+  { date: '2025-08-08', home_team: 'Warrington Wolves', away_team: 'Wigan Warriors', home_score: 18, away_score: 24 },
+  { date: '2025-08-07', home_team: 'Leigh Leopards', away_team: 'Leeds Rhinos', home_score: 14, away_score: 22 },
+  { date: '2025-08-01', home_team: 'St Helens', away_team: 'Castleford Tigers', home_score: 40, away_score: 0 },
+  { date: '2025-08-01', home_team: 'Leigh Leopards', away_team: 'Warrington Wolves', home_score: 20, away_score: 16 },
+  { date: '2025-07-31', home_team: 'Salford Red Devils', away_team: 'Hull KR', home_score: 12, away_score: 74 },
+  { date: '2025-07-26', home_team: 'Hull FC', away_team: 'Huddersfield Giants', home_score: 14, away_score: 30 },
+  { date: '2025-07-25', home_team: 'Wigan Warriors', away_team: 'Catalans Dragons', home_score: 28, away_score: 18 },
+  { date: '2025-07-24', home_team: 'Wakefield Trinity', away_team: 'Leeds Rhinos', home_score: 15, away_score: 14 },
+  { date: '2025-07-20', home_team: 'Castleford Tigers', away_team: 'Warrington Wolves', home_score: 20, away_score: 14 },
+  { date: '2025-07-19', home_team: 'Catalans Dragons', away_team: 'Hull KR', home_score: 6, away_score: 34 },
+  { date: '2025-07-19', home_team: 'Wigan Warriors', away_team: 'Hull FC', home_score: 12, away_score: 32 },
+  { date: '2025-07-18', home_team: 'Huddersfield Giants', away_team: 'Wakefield Trinity', home_score: 10, away_score: 46 },
+  { date: '2025-07-18', home_team: 'Leeds Rhinos', away_team: 'Salford Red Devils', home_score: 42, away_score: 6 },
+  { date: '2025-07-17', home_team: 'St Helens', away_team: 'Leigh Leopards', home_score: 4, away_score: 16 },
+  { date: '2025-07-13', home_team: 'Salford Red Devils', away_team: 'Castleford Tigers', home_score: 26, away_score: 22 },
+  { date: '2025-07-12', home_team: 'Catalans Dragons', away_team: 'Warrington Wolves', home_score: 20, away_score: 24 },
+  { date: '2025-07-12', home_team: 'Leigh Leopards', away_team: 'Hull KR', home_score: 28, away_score: 10 },
+  { date: '2025-07-11', home_team: 'Wigan Warriors', away_team: 'Huddersfield Giants', home_score: 30, away_score: 10 },
+  { date: '2025-07-11', home_team: 'Leeds Rhinos', away_team: 'St Helens', home_score: 0, away_score: 6 },
+  { date: '2025-07-10', home_team: 'Hull FC', away_team: 'Wakefield Trinity', home_score: 16, away_score: 10 },
+  { date: '2025-07-06', home_team: 'Hull KR', away_team: 'Leeds Rhinos', home_score: 8, away_score: 14 },
+  { date: '2025-07-05', home_team: 'Wakefield Trinity', away_team: 'Catalans Dragons', home_score: 44, away_score: 6 },
+  { date: '2025-07-05', home_team: 'Hull FC', away_team: 'St Helens', home_score: 6, away_score: 13 },
+  { date: '2025-07-04', home_team: 'Salford Red Devils', away_team: 'Warrington Wolves', home_score: 12, away_score: 24 },
+  { date: '2025-07-04', home_team: 'Leigh Leopards', away_team: 'Wigan Warriors', home_score: 18, away_score: 8 },
+  { date: '2025-07-03', home_team: 'Castleford Tigers', away_team: 'Huddersfield Giants', home_score: 12, away_score: 30 },
+  { date: '2025-06-29', home_team: 'St Helens', away_team: 'Salford Red Devils', home_score: 58, away_score: 0 },
+  { date: '2025-06-28', home_team: 'Castleford Tigers', away_team: 'Wigan Warriors', home_score: 20, away_score: 26 },
+  { date: '2025-06-28', home_team: 'Catalans Dragons', away_team: 'Huddersfield Giants', home_score: 32, away_score: 0 },
+  { date: '2025-06-28', home_team: 'Warrington Wolves', away_team: 'Hull FC', home_score: 24, away_score: 10 },
+  { date: '2025-06-27', home_team: 'Leeds Rhinos', away_team: 'Leigh Leopards', home_score: 48, away_score: 30 },
+  { date: '2025-06-27', home_team: 'Hull KR', away_team: 'Wakefield Trinity', home_score: 34, away_score: 10 },
+  { date: '2025-06-22', home_team: 'Salford Red Devils', away_team: 'Hull FC', home_score: 6, away_score: 38 },
+  { date: '2025-06-21', home_team: 'Catalans Dragons', away_team: 'Leigh Leopards', home_score: 12, away_score: 26 },
+  { date: '2025-06-21', home_team: 'Warrington Wolves', away_team: 'Huddersfield Giants', home_score: 16, away_score: 24 },
+  { date: '2025-06-20', home_team: 'St Helens', away_team: 'Leeds Rhinos', home_score: 18, away_score: 4 },
+  { date: '2025-06-20', home_team: 'Wakefield Trinity', away_team: 'Wigan Warriors', home_score: 16, away_score: 10 },
+  { date: '2025-06-19', home_team: 'Castleford Tigers', away_team: 'Hull KR', home_score: 0, away_score: 48 },
+  { date: '2025-06-15', home_team: 'Salford Red Devils', away_team: 'St Helens', home_score: 4, away_score: 46 },
+  { date: '2025-06-15', home_team: 'Wakefield Trinity', away_team: 'Leigh Leopards', home_score: 20, away_score: 24 },
+  { date: '2025-06-14', home_team: 'Leeds Rhinos', away_team: 'Warrington Wolves', home_score: 36, away_score: 12 },
+  { date: '2025-06-14', home_team: 'Huddersfield Giants', away_team: 'Wigan Warriors', home_score: 18, away_score: 22 },
+  { date: '2025-06-13', home_team: 'Hull KR', away_team: 'Catalans Dragons', home_score: 68, away_score: 6 },
+  { date: '2025-06-13', home_team: 'Hull FC', away_team: 'Castleford Tigers', home_score: 14, away_score: 22 },
+  { date: '2025-05-31', home_team: 'Catalans Dragons', away_team: 'Hull FC', home_score: 0, away_score: 34 },
+  { date: '2025-05-31', home_team: 'Leeds Rhinos', away_team: 'Wakefield Trinity', home_score: 22, away_score: 18 },
+  { date: '2025-05-30', home_team: 'Hull KR', away_team: 'St Helens', home_score: 34, away_score: 4 },
+  { date: '2025-05-30', home_team: 'Salford Red Devils', away_team: 'Wigan Warriors', home_score: 6, away_score: 46 },
+  { date: '2025-05-30', home_team: 'Warrington Wolves', away_team: 'Castleford Tigers', home_score: 34, away_score: 24 },
+  { date: '2025-05-29', home_team: 'Huddersfield Giants', away_team: 'Leigh Leopards', home_score: 24, away_score: 28 },
+  { date: '2025-05-25', home_team: 'Wakefield Trinity', away_team: 'Salford Red Devils', home_score: 72, away_score: 10 },
+  { date: '2025-05-24', home_team: 'Catalans Dragons', away_team: 'Wigan Warriors', home_score: 0, away_score: 48 },
+  { date: '2025-05-24', home_team: 'Castleford Tigers', away_team: 'Leeds Rhinos', home_score: 6, away_score: 29 },
+  { date: '2025-05-23', home_team: 'Warrington Wolves', away_team: 'Hull KR', home_score: 12, away_score: 31 },
+  { date: '2025-05-23', home_team: 'Huddersfield Giants', away_team: 'St Helens', home_score: 4, away_score: 46 },
+  { date: '2025-05-22', home_team: 'Leigh Leopards', away_team: 'Hull FC', home_score: 12, away_score: 26 },
+  { date: '2025-05-18', home_team: 'Castleford Tigers', away_team: 'Salford Red Devils', home_score: 48, away_score: 16 },
+  { date: '2025-05-18', home_team: 'Wakefield Trinity', away_team: 'Warrington Wolves', home_score: 40, away_score: 10 },
+  { date: '2025-05-17', home_team: 'Hull KR', away_team: 'Huddersfield Giants', home_score: 34, away_score: 0 },
+  { date: '2025-05-16', home_team: 'Wigan Warriors', away_team: 'Leigh Leopards', home_score: 36, away_score: 28 },
+  { date: '2025-05-16', home_team: 'Leeds Rhinos', away_team: 'Hull FC', home_score: 18, away_score: 16 },
+  { date: '2025-05-15', home_team: 'St Helens', away_team: 'Catalans Dragons', home_score: 40, away_score: 0 },
+  { date: '2025-05-04', home_team: 'Castleford Tigers', away_team: 'Wakefield Trinity', home_score: 8, away_score: 32 },
+  { date: '2025-05-04', home_team: 'Wigan Warriors', away_team: 'Warrington Wolves', home_score: 22, away_score: 20 },
+  { date: '2025-05-04', home_team: 'Huddersfield Giants', away_team: 'Hull FC', home_score: 12, away_score: 10 },
+  { date: '2025-05-03', home_team: 'St Helens', away_team: 'Leeds Rhinos', home_score: 4, away_score: 17 },
+  { date: '2025-05-03', home_team: 'Hull KR', away_team: 'Salford Red Devils', home_score: 54, away_score: 0 },
+  { date: '2025-05-03', home_team: 'Leigh Leopards', away_team: 'Catalans Dragons', home_score: 26, away_score: 24 },
+  { date: '2025-04-27', home_team: 'Hull FC', away_team: 'Wigan Warriors', home_score: 12, away_score: 36 },
+  { date: '2025-04-26', home_team: 'Salford Red Devils', away_team: 'Leigh Leopards', home_score: 6, away_score: 28 },
+  { date: '2025-04-26', home_team: 'Catalans Dragons', away_team: 'Wakefield Trinity', home_score: 24, away_score: 20 },
+  { date: '2025-04-26', home_team: 'Huddersfield Giants', away_team: 'Castleford Tigers', home_score: 12, away_score: 30 },
+  { date: '2025-04-25', home_team: 'Leeds Rhinos', away_team: 'Hull KR', home_score: 14, away_score: 20 },
+  { date: '2025-04-24', home_team: 'Warrington Wolves', away_team: 'St Helens', home_score: 32, away_score: 18 },
+  { date: '2025-04-19', home_team: 'Catalans Dragons', away_team: 'Salford Red Devils', home_score: 38, away_score: 10 },
+  { date: '2025-04-19', home_team: 'Leigh Leopards', away_team: 'Warrington Wolves', home_score: 18, away_score: 14 },
+  { date: '2025-04-18', home_team: 'Leeds Rhinos', away_team: 'Huddersfield Giants', home_score: 28, away_score: 6 },
+  { date: '2025-04-18', home_team: 'Wigan Warriors', away_team: 'St Helens', home_score: 24, away_score: 14 },
+  { date: '2025-04-18', home_team: 'Hull FC', away_team: 'Hull KR', home_score: 14, away_score: 28 },
+  { date: '2025-04-17', home_team: 'Wakefield Trinity', away_team: 'Castleford Tigers', home_score: 13, away_score: 12 },
+  { date: '2025-04-13', home_team: 'Huddersfield Giants', away_team: 'Catalans Dragons', home_score: 18, away_score: 38 },
+  { date: '2025-04-12', home_team: 'Castleford Tigers', away_team: 'Leigh Leopards', home_score: 6, away_score: 20 },
+  { date: '2025-04-12', home_team: 'Warrington Wolves', away_team: 'Hull FC', home_score: 16, away_score: 28 },
+  { date: '2025-04-11', home_team: 'Hull KR', away_team: 'Wigan Warriors', home_score: 12, away_score: 28 },
+  { date: '2025-04-11', home_team: 'St Helens', away_team: 'Wakefield Trinity', home_score: 26, away_score: 14 },
+  { date: '2025-04-10', home_team: 'Salford Red Devils', away_team: 'Leeds Rhinos', home_score: 0, away_score: 28 },
+  { date: '2025-03-30', home_team: 'Wigan Warriors', away_team: 'Salford Red Devils', home_score: 54, away_score: 0 },
+  { date: '2025-03-30', home_team: 'Huddersfield Giants', away_team: 'Hull KR', home_score: 4, away_score: 50 },
+  { date: '2025-03-29', home_team: 'Catalans Dragons', away_team: 'St Helens', home_score: 13, away_score: 14 },
+  { date: '2025-03-28', home_team: 'Warrington Wolves', away_team: 'Leeds Rhinos', home_score: 16, away_score: 14 },
+  { date: '2025-03-28', home_team: 'Leigh Leopards', away_team: 'Wakefield Trinity', home_score: 14, away_score: 40 },
+  { date: '2025-03-27', home_team: 'Castleford Tigers', away_team: 'Hull FC', home_score: 14, away_score: 24 },
+  { date: '2025-03-23', home_team: 'Hull KR', away_team: 'Leigh Leopards', home_score: 30, away_score: 0 },
+  { date: '2025-03-22', home_team: 'Leeds Rhinos', away_team: 'Wigan Warriors', home_score: 12, away_score: 10 },
+  { date: '2025-03-22', home_team: 'Castleford Tigers', away_team: 'Catalans Dragons', home_score: 4, away_score: 26 },
+  { date: '2025-03-21', home_team: 'St Helens', away_team: 'Warrington Wolves', home_score: 12, away_score: 14 },
+  { date: '2025-03-21', home_team: 'Wakefield Trinity', away_team: 'Hull FC', home_score: 12, away_score: 16 },
+  { date: '2025-03-20', home_team: 'Salford Red Devils', away_team: 'Huddersfield Giants', home_score: 23, away_score: 10 },
+  { date: '2025-03-09', home_team: 'Warrington Wolves', away_team: 'Wakefield Trinity', home_score: 16, away_score: 30 },
+  { date: '2025-03-09', home_team: 'Wigan Warriors', away_team: 'Huddersfield Giants', home_score: 44, away_score: 18 },
+  { date: '2025-03-08', home_team: 'Catalans Dragons', away_team: 'Leeds Rhinos', home_score: 11, away_score: 0 },
+  { date: '2025-03-07', home_team: 'St Helens', away_team: 'Hull KR', home_score: 10, away_score: 20 },
+  { date: '2025-03-07', home_team: 'Castleford Tigers', away_team: 'Salford Red Devils', home_score: 22, away_score: 14 },
+  { date: '2025-03-06', home_team: 'Hull FC', away_team: 'Leigh Leopards', home_score: 22, away_score: 22 },
+  { date: '2025-03-02', home_team: 'Leeds Rhinos', away_team: 'Castleford Tigers', home_score: 38, away_score: 24 },
+  { date: '2025-03-01', home_team: 'Wigan Warriors', away_team: 'Warrington Wolves', home_score: 48, away_score: 24 },
+  { date: '2025-03-01', home_team: 'Wakefield Trinity', away_team: 'St Helens', home_score: 6, away_score: 26 },
+  { date: '2025-02-28', home_team: 'Huddersfield Giants', away_team: 'Hull FC', home_score: 10, away_score: 11 },
+  { date: '2025-02-28', home_team: 'Leigh Leopards', away_team: 'Catalans Dragons', home_score: 34, away_score: 6 },
+  { date: '2025-02-27', home_team: 'Hull KR', away_team: 'Salford Red Devils', home_score: 42, away_score: 0 },
+  { date: '2025-02-23', home_team: 'Leigh Leopards', away_team: 'Huddersfield Giants', home_score: 24, away_score: 10 },
+  { date: '2025-02-22', home_team: 'Castleford Tigers', away_team: 'St Helens', home_score: 6, away_score: 46 },
+  { date: '2025-02-22', home_team: 'Salford Red Devils', away_team: 'Leeds Rhinos', home_score: 6, away_score: 32 },
+  { date: '2025-02-21', home_team: 'Warrington Wolves', away_team: 'Catalans Dragons', home_score: 18, away_score: 12 },
+  { date: '2025-02-21', home_team: 'Hull FC', away_team: 'Wigan Warriors', home_score: 4, away_score: 46 },
+  { date: '2025-02-20', home_team: 'Wakefield Trinity', away_team: 'Hull KR', home_score: 12, away_score: 14 },
+  { date: '2025-02-16', home_team: 'Huddersfield Giants', away_team: 'Warrington Wolves', home_score: 12, away_score: 20 },
+  { date: '2025-02-15', home_team: 'St Helens', away_team: 'Salford Red Devils', home_score: 82, away_score: 0 },
+  { date: '2025-02-15', home_team: 'Leeds Rhinos', away_team: 'Wakefield Trinity', home_score: 12, away_score: 14 },
+  { date: '2025-02-14', home_team: 'Hull KR', away_team: 'Castleford Tigers', home_score: 19, away_score: 18 },
+  { date: '2025-02-14', home_team: 'Catalans Dragons', away_team: 'Hull FC', home_score: 4, away_score: 24 },
+  { date: '2025-02-13', home_team: 'Wigan Warriors', away_team: 'Leigh Leopards', home_score: 0, away_score: 1 },
+];
+
+const pastResults2025 = RAW_2025_RESULTS.reduce<Match[]>((accumulator, result, index) => {
+  const homeTeam = TEAM_NAME_LOOKUP[result.home_team];
+  const awayTeam = TEAM_NAME_LOOKUP[result.away_team];
+
+  if (!homeTeam || !awayTeam) {
+    return accumulator;
+  }
+
+  const venue = teamIdToVenue[homeTeam.id] ?? homeTeam.name;
+
+  accumulator.push(
+    createMatchOnDate(
+      2000 + index,
+      homeTeam,
+      awayTeam,
+      'FULL-TIME',
+      createKickoffDate(result.date, index),
+      result.home_score,
+      result.away_score,
+      venue
+    )
+  );
+
+  return accumulator;
+}, []);
+
+// ---------- Mock data ----------
+export const mockMatches: Match[] = [
+  // Upcoming play-off fixtures
+  createMatchOnDate(
+    114,
+    TEAMS.hullKR,
+    TEAMS.stHelens,
+    'SCHEDULED',
+    new Date('2025-10-04T17:30:00+01:00'),
+    0,
+    0,
+    teamIdToVenue[TEAMS.hullKR.id]
+  ),
+  createMatchOnDate(
+    115,
+    WINNER_SF1,
+    WINNER_SF2,
+    'SCHEDULED',
+    new Date('2025-10-11T18:00:00+01:00'),
+    0,
+    0,
+    VENUES.oldTrafford
+  ),
+
+  ...pastResults2025,
+];
+
+export const mockLeagueTable: LeagueStanding[] = [
+  { rank: 1, teamId: TEAMS.hullKR.id, teamName: 'Hull KR', teamLogoUrl: TEAMS.hullKR.logoUrl, played: 27, wins: 22, draws: 0, losses: 5, points: 44, form: 'L W W W W' },
+  { rank: 2, teamId: TEAMS.wigan.id, teamName: 'Wigan Warriors', teamLogoUrl: TEAMS.wigan.logoUrl, played: 27, wins: 21, draws: 0, losses: 6, points: 42, form: 'W W W W W' },
+  { rank: 3, teamId: TEAMS.leigh.id, teamName: 'Leigh Leopards', teamLogoUrl: TEAMS.leigh.logoUrl, played: 27, wins: 19, draws: 1, losses: 7, points: 39, form: 'W W W W W' },
+  { rank: 4, teamId: TEAMS.leeds.id, teamName: 'Leeds Rhinos', teamLogoUrl: TEAMS.leeds.logoUrl, played: 27, wins: 18, draws: 0, losses: 9, points: 36, form: 'W W W L L' },
+  { rank: 5, teamId: TEAMS.stHelens.id, teamName: 'St Helens', teamLogoUrl: TEAMS.stHelens.logoUrl, played: 27, wins: 17, draws: 0, losses: 10, points: 34, form: 'W L L L W' },
+  { rank: 6, teamId: TEAMS.wakefield.id, teamName: 'Wakefield Trinity', teamLogoUrl: TEAMS.wakefield.logoUrl, played: 27, wins: 15, draws: 0, losses: 12, points: 30, form: 'L W L W W' },
+  { rank: 7, teamId: TEAMS.hullFC.id, teamName: 'Hull FC', teamLogoUrl: TEAMS.hullFC.logoUrl, played: 27, wins: 13, draws: 1, losses: 13, points: 27, form: 'L L L W L' },
+  { rank: 8, teamId: TEAMS.warrington.id, teamName: 'Warrington Wolves', teamLogoUrl: TEAMS.warrington.logoUrl, played: 27, wins: 10, draws: 0, losses: 17, points: 20, form: 'L L L L L' },
+  { rank: 9, teamId: TEAMS.catalans.id, teamName: 'Catalans Dragons', teamLogoUrl: TEAMS.catalans.logoUrl, played: 27, wins: 10, draws: 0, losses: 17, points: 20, form: 'W L W W W' },
+  { rank: 10, teamId: TEAMS.huddersfield.id, teamName: 'Huddersfield Giants', teamLogoUrl: TEAMS.huddersfield.logoUrl, played: 27, wins: 7, draws: 0, losses: 20, points: 14, form: 'W L L W L' },
+  { rank: 11, teamId: TEAMS.castleford.id, teamName: 'Castleford Tigers', teamLogoUrl: TEAMS.castleford.logoUrl, played: 27, wins: 6, draws: 0, losses: 21, points: 12, form: 'L L W L L' },
+  { rank: 12, teamId: TEAMS.salford.id, teamName: 'Salford Red Devils', teamLogoUrl: TEAMS.salford.logoUrl, played: 27, wins: 3, draws: 0, losses: 24, points: 4, form: 'L W L L L' }
+];

--- a/the-scrum-book-nextjs/src/services/profileService.ts
+++ b/the-scrum-book-nextjs/src/services/profileService.ts
@@ -1,0 +1,20 @@
+import type { Profile } from '@/types';
+
+/**
+ * @deprecated Profile management is now handled via localStorage and this service is no longer in use.
+ */
+
+export const getProfiles = async (): Promise<Record<string, Profile>> => {
+    console.warn('getProfiles is deprecated.');
+    return Promise.resolve({});
+};
+
+export const updateProfile = async (id: string, profile: Profile): Promise<Profile> => {
+    console.warn('updateProfile is deprecated.');
+    return Promise.resolve(profile);
+};
+
+export const deleteProfile = async (id: string): Promise<void> => {
+    console.warn('deleteProfile is deprecated.');
+    return Promise.resolve();
+};

--- a/the-scrum-book-nextjs/src/services/stadiumData.ts
+++ b/the-scrum-book-nextjs/src/services/stadiumData.ts
@@ -1,0 +1,95 @@
+import type { TeamInfo } from '@/types';
+
+export const teamsData: TeamInfo[] = [
+    {
+        name: 'Castleford Tigers',
+        established: 1926,
+        titles: '0',
+        location: 'Castleford, West Yorkshire',
+        stadium: { name: 'The Jungle (Mend-A-Hose Jungle)', capacity: '11,775', notes: 'Known for its passionate atmosphere.' }
+    },
+    {
+        name: 'Catalans Dragons',
+        established: 2000,
+        titles: '0',
+        location: 'Perpignan, France',
+        stadium: { name: 'Stade Gilbert Brutus', capacity: '13,000', notes: 'The only non-English team in the league.' }
+    },
+    {
+        name: 'Huddersfield Giants',
+        established: 1864,
+        titles: '7 (last 1962)',
+        location: 'Huddersfield, West Yorkshire',
+        stadium: { name: 'John Smith\'s Stadium', capacity: '24,500', notes: 'Shared with Huddersfield Town F.C.' }
+    },
+    {
+        name: 'Hull F.C.',
+        established: 1865,
+        titles: '6 (last 1983)',
+        location: 'Kingston upon Hull, East Yorkshire',
+        stadium: { name: 'MKM Stadium', capacity: '25,400', notes: 'Shared with Hull City A.F.C.' }
+    },
+    {
+        name: 'Hull Kingston Rovers',
+        established: 1882,
+        titles: '5 (last 1985)',
+        location: 'Kingston upon Hull, East Yorkshire',
+        stadium: { name: 'Sewell Group Craven Park', capacity: '12,225', notes: 'Located on the east side of the city.' }
+    },
+    {
+        name: 'Leeds Rhinos',
+        established: 1870,
+        titles: '11 (last 2017)',
+        location: 'Leeds, West Yorkshire',
+        stadium: { name: 'Headingley Stadium', capacity: '19,700', notes: 'Also a major cricket venue.' }
+    },
+    {
+        name: 'Leigh Leopards',
+        established: 1878,
+        titles: '2 (last 1982)',
+        location: 'Leigh, Greater Manchester',
+        stadium: { name: 'Leigh Sports Village', capacity: '12,005', notes: 'A modern stadium and leisure complex.' }
+    },
+     {
+        name: 'London Broncos',
+        established: 1980,
+        titles: '0',
+        location: 'Wimbledon, London',
+        stadium: { name: 'Cherry Red Records Stadium', capacity: '9,215', notes: 'Shared with AFC Wimbledon.' }
+    },
+    {
+        name: 'Salford Red Devils',
+        established: 1873,
+        titles: '6 (last 1976)',
+        location: 'Salford, Greater Manchester',
+        stadium: { name: 'Salford Community Stadium', capacity: '12,000', notes: 'Shared with Sale Sharks Rugby Union Club.' }
+    },
+    {
+        name: 'St Helens',
+        established: 1873,
+        titles: '17 (last 2022)',
+        location: 'St Helens, Merseyside',
+        stadium: { name: 'Totally Wicked Stadium', capacity: '18,000', notes: 'Purpose-built for the club, opened in 2012.' }
+    },
+    {
+        name: 'Wakefield Trinity',
+        established: 1873,
+        titles: '2 (last 1968)',
+        location: 'Wakefield, West Yorkshire',
+        stadium: { name: 'Belle Vue', capacity: '9,333', notes: 'A historic ground with one of the league\'s oldest stands.' }
+    },
+    {
+        name: 'Warrington Wolves',
+        established: 1876,
+        titles: '3 (last 1955)',
+        location: 'Warrington, Cheshire',
+        stadium: { name: 'Halliwell Jones Stadium', capacity: '15,200', notes: 'Opened in 2004, located close to the town centre.' }
+    },
+    {
+        name: 'Wigan Warriors',
+        established: 1872,
+        titles: '24 (last 2024)',
+        location: 'Wigan, Greater Manchester',
+        stadium: { name: 'The Brick Community Stadium', capacity: '25,133', notes: 'Previously known as the DW Stadium.' }
+    }
+];

--- a/the-scrum-book-nextjs/src/types.ts
+++ b/the-scrum-book-nextjs/src/types.ts
@@ -1,0 +1,197 @@
+// Explicit React type imports so this file compiles without relying on a global React namespace
+import type { FC, SVGProps } from 'react';
+
+// This file defines the core data structures for the application.
+// By centralizing types, we ensure consistency across components and services.
+
+export type View =
+  | 'UPCOMING'
+  | 'MATCH_DAY'
+  | 'LEAGUE_TABLE'
+  | 'GROUNDS'
+  | 'MY_MATCHES'
+  | 'STATS'
+  | 'ABOUT'
+  | 'BADGES'
+  | 'PROFILE'
+  | 'TEAM_STATS'
+  | 'NEARBY'
+  | 'PREDICTION_GAMES'
+  | 'ADMIN'
+  | 'COMMUNITY';
+
+export interface Team {
+  id: string;
+  name: string;
+  logoUrl: string;
+}
+
+export interface MatchStats {
+  possession: {
+    home: number;
+    away: number;
+  };
+  territory: {
+    home: number;
+    away: number;
+  };
+  tackles: {
+    home: number;
+    away: number;
+  };
+}
+
+export interface Match {
+  id: string;
+  competition: {
+    id: string;
+    name: string;
+  };
+  homeTeam: Team;
+  awayTeam: Team;
+  status: 'SCHEDULED' | 'FULL-TIME';
+  startTime: string; // ISO 8601 format
+  venue: string;
+  scores: {
+    home: number;
+    away: number;
+  };
+  stats?: MatchStats;
+}
+
+export interface AttendedMatch {
+  match: Match;
+  attendedOn: string; // ISO 8601 format
+  photoUrl?: string;
+}
+
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  category: 'Milestone' | 'Tournament';
+  icon: FC<SVGProps<SVGSVGElement>>;
+}
+
+export interface LeagueStanding {
+  rank: number;
+  teamId: string;
+  teamName: string;
+  teamLogoUrl: string;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  points: number;
+  form: string; // e.g., "WWLWL"
+}
+
+export interface Venue {
+  name: string;
+  team: string;
+  lat: number;
+  lon: number;
+  x?: number; // for SVG map
+  y?: number; // for SVG map
+}
+
+export interface User {
+  name: string;
+  favoriteTeamId?: string;
+  avatarUrl?: string;
+  avatarSource?: 'google' | 'custom' | 'generated';
+  avatarUpdatedAt?: string;
+}
+
+export interface AuthUser {
+  uid: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  email?: string | null;
+  isAnonymous?: boolean;
+}
+
+export interface StadiumInfo {
+  name: string;
+  capacity: string;
+  notes: string;
+}
+
+export interface TeamInfo {
+  name: string;
+  established: number;
+  titles: string;
+  location: string;
+  stadium: StadiumInfo;
+}
+
+// New types for multi-profile support
+export type PredictionOutcome = 'HOME_WIN' | 'AWAY_WIN' | 'DRAW';
+
+export type PredictionConfidence = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export interface Prediction {
+  id: string;
+  matchId: string;
+  outcome: PredictionOutcome;
+  confidence?: PredictionConfidence;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SaveUserPredictionInput {
+  matchId: string;
+  outcome: PredictionOutcome;
+  confidence?: PredictionConfidence;
+  notes?: string;
+}
+
+export interface Profile {
+  user: User;
+  attendedMatches: AttendedMatch[];
+  earnedBadgeIds: string[];
+  friendIds: string[];
+  predictions: Prediction[];
+}
+
+export interface ScrumBookData {
+  profiles: Record<string, Profile>;
+  activeProfileId: string | null;
+}
+
+export interface MatchVenueDetails {
+  name: string;
+  city?: string;
+  capacity?: number;
+  notes?: string;
+}
+
+export interface MatchWithVenue {
+  id: string;
+  round?: string;
+  competitionName?: string;
+  homeTeam: string;
+  awayTeam: string;
+  date: string;
+  kickoffTime?: string;
+  headline?: string;
+  broadcast?: string;
+  venue: MatchVenueDetails;
+}
+
+export interface MatchAttendance {
+  matchId: string;
+  attendedOn: string;
+  notes?: string;
+  rating?: number;
+}
+
+export interface AttendanceStats {
+  totalMatches: number;
+  uniqueVenues: number;
+  currentStreak: number;
+  favouriteVenue?: string;
+  firstMatchDate?: string;
+  recentAttendance?: MatchWithVenue;
+}

--- a/the-scrum-book-nextjs/src/utils/date.ts
+++ b/the-scrum-book-nextjs/src/utils/date.ts
@@ -1,0 +1,13 @@
+export const formatDateUK = (dateInput: string | number | Date): string => {
+  const date = new Date(dateInput);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};

--- a/the-scrum-book-nextjs/src/utils/geolocation.ts
+++ b/the-scrum-book-nextjs/src/utils/geolocation.ts
@@ -1,0 +1,18 @@
+/**
+ * Calculates the distance between two geographical coordinates using the Haversine formula.
+ * @param lat1 Latitude of the first point.
+ * @param lon1 Longitude of the first point.
+ * @param lat2 Latitude of the second point.
+ * @param lon2 Longitude of the second point.
+ * @returns The distance in miles.
+ */
+export const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
+    const R = 3959; // Radius of the Earth in miles
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLon = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+};

--- a/the-scrum-book-nextjs/src/utils/share.ts
+++ b/the-scrum-book-nextjs/src/utils/share.ts
@@ -1,0 +1,56 @@
+export type ShareOutcome = 'shared' | 'copied' | 'failed';
+
+export interface ShareContent {
+  title: string;
+  text: string;
+  url?: string;
+  clipboardFallbackText?: string;
+}
+
+const getClipboardPayload = ({ text, url, clipboardFallbackText }: ShareContent) => {
+  if (clipboardFallbackText) {
+    return clipboardFallbackText;
+  }
+
+  if (text && url) {
+    return `${text} ${url}`.trim();
+  }
+
+  return text || url || '';
+};
+
+export const attemptShare = async (content: ShareContent): Promise<ShareOutcome> => {
+  if (typeof navigator !== 'undefined' && 'share' in navigator) {
+    try {
+      await (navigator as Navigator & { share: (data: ShareData) => Promise<void> }).share({
+        title: content.title,
+        text: content.text,
+        url: content.url,
+      });
+      return 'shared';
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return 'shared';
+      }
+    }
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(getClipboardPayload(content));
+      return 'copied';
+    } catch {
+      // no-op fallthrough
+    }
+  }
+
+  return 'failed';
+};
+
+export const getAppShareUrl = () => {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+
+  return 'https://thescrumbook.com';
+};

--- a/the-scrum-book-nextjs/src/utils/themeUtils.ts
+++ b/the-scrum-book-nextjs/src/utils/themeUtils.ts
@@ -1,0 +1,349 @@
+import { TEAM_BRANDING } from '@/services/mockData';
+import type { TeamBranding } from '@/services/mockData';
+
+export type ThemeMode = 'light' | 'dark';
+interface ThemeVariables {
+  primary: string;
+  secondary: string;
+  accent: string;
+  danger: string;
+  warning: string;
+  info: string;
+  success: string;
+  textStrong: string;
+  text: string;
+  textSubtle: string;
+  border: string;
+  surface: string;
+  surfaceAlt: string;
+  gradient1: string;
+  gradient2: string;
+  gradient3: string;
+}
+
+const DEFAULT_LIGHT_THEME: ThemeVariables = {
+  primary: '#7F1028',
+  secondary: '#FFD447',
+  accent: '#0052CC',
+  danger: '#7F1028',
+  warning: '#FFD447',
+  info: '#0052CC',
+  success: '#00A86B',
+  textStrong: '#121212',
+  text: '#333333',
+  textSubtle: '#666666',
+  border: '#DDDDDD',
+  surface: '#FFFFFF',
+  surfaceAlt: '#F5F5F5',
+  gradient1: 'linear-gradient(140deg, rgba(127, 16, 40, 0.12), rgba(0, 82, 204, 0.1))',
+  gradient2: 'radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.18), transparent 55%)',
+  gradient3: 'radial-gradient(circle at 80% 0%, rgba(127, 16, 40, 0.14), transparent 45%)',
+};
+
+const DEFAULT_DARK_THEME: ThemeVariables = {
+  primary: '#B71E3C',
+  secondary: '#FFDD57',
+  accent: '#0074FF',
+  danger: '#B71E3C',
+  warning: '#FFDD57',
+  info: '#3B82F6',
+  success: '#22C55E',
+  textStrong: '#FFFFFF',
+  text: '#E0E0E0',
+  textSubtle: '#A0A0A0',
+  border: '#404040',
+  surface: '#1A1A1A',
+  surfaceAlt: '#2C2C2C',
+  gradient1: 'linear-gradient(140deg, rgba(183, 30, 60, 0.24), rgba(0, 116, 255, 0.18))',
+  gradient2: 'radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.22), transparent 60%)',
+  gradient3: 'radial-gradient(circle at 90% 10%, rgba(183, 30, 60, 0.2), transparent 55%)',
+};
+
+const VARIABLE_NAME_MAP: Record<keyof ThemeVariables, string> = {
+  primary: '--clr-primary',
+  secondary: '--clr-secondary',
+  accent: '--clr-accent',
+  danger: '--clr-danger',
+  warning: '--clr-warning',
+  info: '--clr-info',
+  success: '--clr-success',
+  textStrong: '--clr-text-strong',
+  text: '--clr-text',
+  textSubtle: '--clr-text-subtle',
+  border: '--clr-border',
+  surface: '--clr-surface',
+  surfaceAlt: '--clr-surface-alt',
+  gradient1: '--gradient-1',
+  gradient2: '--gradient-2',
+  gradient3: '--gradient-3',
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const hexToRgb = (hex: string): [number, number, number] | null => {
+  const normalised = hex.replace('#', '');
+  if (normalised.length === 3) {
+    const r = normalised[0];
+    const g = normalised[1];
+    const b = normalised[2];
+    return [parseInt(r.repeat(2), 16), parseInt(g.repeat(2), 16), parseInt(b.repeat(2), 16)];
+  }
+
+  if (normalised.length !== 6) {
+    return null;
+  }
+
+  const r = parseInt(normalised.slice(0, 2), 16);
+  const g = parseInt(normalised.slice(2, 4), 16);
+  const b = parseInt(normalised.slice(4, 6), 16);
+
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return null;
+  }
+
+  return [r, g, b];
+};
+
+const rgbToHex = (r: number, g: number, b: number): string => {
+  const toHex = (component: number) => clamp(Math.round(component), 0, 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const mixHexColors = (hexA: string, hexB: string, amount: number): string => {
+  const weight = clamp(amount, 0, 1);
+  const rgbA = hexToRgb(hexA);
+  const rgbB = hexToRgb(hexB);
+
+  if (!rgbA || !rgbB) {
+    return rgbA ? rgbToHex(...rgbA) : hexA;
+  }
+
+  const [rA, gA, bA] = rgbA;
+  const [rB, gB, bB] = rgbB;
+
+  const r = rA + (rB - rA) * weight;
+  const g = gA + (gB - gA) * weight;
+  const b = bA + (bB - bA) * weight;
+
+  return rgbToHex(r, g, b);
+};
+
+const hexToRgba = (hex: string, alpha: number): string => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return `rgba(0, 0, 0, ${clamp(alpha, 0, 1)})`;
+  }
+  const [r, g, b] = rgb;
+  return `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1)})`;
+};
+
+const hexToHsl = (hex: string): [number, number, number] | null => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) {
+    return null;
+  }
+
+  const [r, g, b] = rgb.map(component => component / 255) as [number, number, number];
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  const delta = max - min;
+  if (delta === 0) {
+    return [0, 0, l];
+  }
+
+  s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+
+  switch (max) {
+    case r:
+      h = (g - b) / delta + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / delta + 2;
+      break;
+    case b:
+      h = (r - g) / delta + 4;
+      break;
+    default:
+      h = 0;
+  }
+
+  h /= 6;
+
+  return [h, s, l];
+};
+
+const hueToRgb = (p: number, q: number, t: number) => {
+  let temp = t;
+  if (temp < 0) {
+    temp += 1;
+  }
+  if (temp > 1) {
+    temp -= 1;
+  }
+  if (temp < 1 / 6) {
+    return p + (q - p) * 6 * temp;
+  }
+  if (temp < 1 / 2) {
+    return q;
+  }
+  if (temp < 2 / 3) {
+    return p + (q - p) * (2 / 3 - temp) * 6;
+  }
+  return p;
+};
+
+const hslToHex = (h: number, s: number, l: number): string => {
+  const hue = ((h % 1) + 1) % 1;
+  const saturation = clamp(s, 0, 1);
+  const lightness = clamp(l, 0, 1);
+
+  if (saturation === 0) {
+    const gray = Math.round(lightness * 255);
+    return rgbToHex(gray, gray, gray);
+  }
+
+  const q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+
+  const r = Math.round(hueToRgb(p, q, hue + 1 / 3) * 255);
+  const g = Math.round(hueToRgb(p, q, hue) * 255);
+  const b = Math.round(hueToRgb(p, q, hue - 1 / 3) * 255);
+
+  return rgbToHex(r, g, b);
+};
+
+const adjustColorIntensity = (
+  hex: string,
+  { saturationMultiplier = 1, lightnessMultiplier = 1, lightnessBias = 0 }: {
+    saturationMultiplier?: number;
+    lightnessMultiplier?: number;
+    lightnessBias?: number;
+  },
+): string => {
+  const hsl = hexToHsl(hex);
+  if (!hsl) {
+    return hex;
+  }
+
+  const [h, s, l] = hsl;
+  const adjustedS = clamp(s * saturationMultiplier, 0, 1);
+  const adjustedL = clamp(l * lightnessMultiplier + lightnessBias, 0, 1);
+
+  return hslToHex(h, adjustedS, adjustedL);
+};
+
+const emphasisePrimaryColor = (hex: string, mode: ThemeMode) =>
+  adjustColorIntensity(hex, {
+    saturationMultiplier: 1.12,
+    lightnessMultiplier: mode === 'dark' ? 1.08 : 1,
+  });
+
+const createTeamOverrides = (
+  branding: TeamBranding,
+  mode: ThemeMode,
+  defaults: ThemeVariables,
+): Partial<ThemeVariables> => {
+  const palette = branding.palette && branding.palette.length > 0 ? branding.palette : [branding.bg, branding.text];
+  const [rawPrimary, rawSecondary, rawTertiary] = palette;
+
+  const primary = emphasisePrimaryColor(rawPrimary ?? branding.bg, mode);
+
+  const secondaryBase = rawSecondary ?? mixHexColors(primary, '#FFFFFF', mode === 'dark' ? 0.18 : 0.28);
+  const accentBase = rawTertiary ?? rawSecondary ?? adjustColorIntensity(primary, {
+    saturationMultiplier: 0.95,
+    lightnessMultiplier: mode === 'dark' ? 1.22 : 0.88,
+  });
+
+  const secondary = adjustColorIntensity(secondaryBase, {
+    saturationMultiplier: 1.08,
+    lightnessMultiplier: mode === 'dark' ? 1.04 : 0.98,
+  });
+
+  const accent = adjustColorIntensity(accentBase, {
+    saturationMultiplier: 1.1,
+    lightnessMultiplier: mode === 'dark' ? 1.02 : 0.96,
+  });
+
+  const warning = adjustColorIntensity(rawSecondary ?? mixHexColors(primary, '#F97316', 0.45), {
+    saturationMultiplier: 1.05,
+    lightnessMultiplier: mode === 'dark' ? 1 : 0.98,
+  });
+
+  const info = adjustColorIntensity(mixHexColors(accent, '#2563EB', 0.35), {
+    saturationMultiplier: 1.05,
+    lightnessMultiplier: mode === 'dark' ? 1 : 0.97,
+  });
+
+  const success = adjustColorIntensity(mixHexColors(accent, '#16A34A', 0.4), {
+    saturationMultiplier: 1.08,
+    lightnessMultiplier: mode === 'dark' ? 1 : 0.97,
+  });
+
+  const border = adjustColorIntensity(mixHexColors(defaults.border, primary, mode === 'dark' ? 0.38 : 0.24), {
+    saturationMultiplier: 1.05,
+    lightnessMultiplier: mode === 'dark' ? 1 : 0.92,
+  });
+
+  const surface = mixHexColors(defaults.surface, primary, mode === 'dark' ? 0.12 : 0.07);
+  const surfaceAlt = mixHexColors(defaults.surfaceAlt, primary, mode === 'dark' ? 0.16 : 0.1);
+
+  const gradient1 = `linear-gradient(135deg, ${hexToRgba(primary, mode === 'dark' ? 0.65 : 0.5)}, ${hexToRgba(accent, mode === 'dark' ? 0.52 : 0.35)})`;
+  const gradient2 = `radial-gradient(circle at 18% 20%, ${hexToRgba(secondary, mode === 'dark' ? 0.5 : 0.32)}, transparent 56%)`;
+  const gradient3 = `radial-gradient(circle at 78% -10%, ${hexToRgba(primary, mode === 'dark' ? 0.5 : 0.28)}, transparent 48%)`;
+
+  return {
+    primary,
+    secondary,
+    accent,
+    danger: primary,
+    warning,
+    info,
+    success,
+    border,
+    surface,
+    surfaceAlt,
+    gradient1,
+    gradient2,
+    gradient3,
+  };
+};
+
+const getDefaultsForMode = (mode: ThemeMode) => (mode === 'dark' ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME);
+
+export const getThemeVariables = (teamId: string | undefined, mode: ThemeMode): ThemeVariables => {
+  const defaults = getDefaultsForMode(mode);
+
+  if (!teamId) {
+    return defaults;
+  }
+
+  const branding = TEAM_BRANDING[teamId];
+  if (!branding) {
+    return defaults;
+  }
+
+  const overrides = createTeamOverrides(branding, mode, defaults);
+  return { ...defaults, ...overrides };
+};
+
+const applyVariablesToRoot = (variables: ThemeVariables, mode: ThemeMode) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  (Object.keys(VARIABLE_NAME_MAP) as Array<keyof ThemeVariables>).forEach(key => {
+    const cssVar = VARIABLE_NAME_MAP[key];
+    root.style.setProperty(cssVar, variables[key]);
+  });
+  root.style.setProperty('color-scheme', mode);
+};
+
+export const syncThemeWithFavouriteTeam = (teamId: string | undefined, mode: ThemeMode) => {
+  const variables = getThemeVariables(teamId, mode);
+  applyVariablesToRoot(variables, mode);
+};


### PR DESCRIPTION
## Summary
- copy the Vite UI components, hooks, services, utils, contexts, and supporting badge/type modules into the Next.js src tree
- update imports to use the @/ alias and mark React-driven modules with the `use client` directive for App Router compatibility

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0daa23fb0832cb1cc742ad81e9504