### PR TITLE
Initialize Firebase Functions auth trigger

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "source": "functions"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [

--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: {
+    es6: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['tsconfig.json'],
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off'
+  },
+};

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+lib
+.eslintcache
+

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "functions",
+  "version": "1.0.0",
+  "description": "Cloud Functions for Firebase",
+  "engines": {
+    "node": "18"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint --ext .ts src",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "test": "echo \"No tests specified\""
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.7.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "eslint": "^8.55.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1"
+  },
+  "private": true
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,16 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export const logNewUserEmail = functions.auth.user().onCreate((user) => {
+  const { email } = user;
+
+  if (email) {
+    console.log(`A new user was created with email: ${email}`);
+  } else {
+    console.log('A new user was created without a provided email.');
+  }
+});

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "target": "es2017",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "compileOnSave": true,
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Firebase Functions workspace configured for TypeScript compilation and linting
- create an auth user creation trigger that logs the new user's email address
- configure firebase.json to deploy both hosting and the new functions directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e065881c832c9cf662ca7953f1bc