### PR TITLE
Port App component to Next.js home page

### DIFF
--- a/the-scrum-book-nextjs/src/app/layout.tsx
+++ b/the-scrum-book-nextjs/src/app/layout.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
-import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
@@ -25,74 +24,72 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full bg-slate-950">
       <body className={`${inter.variable} h-full bg-slate-950 text-slate-100 antialiased`}>
-        <Providers>
-          <div className="relative min-h-screen overflow-hidden">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(30,64,175,0.35),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(6,182,212,0.25),_transparent_55%)]" aria-hidden="true" />
-            <div className="relative flex min-h-screen flex-col">
-              <header className="border-b border-white/10 bg-slate-950/80 backdrop-blur">
-                <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 py-5 sm:px-6 lg:px-8">
-                  <Link href="/" className="flex items-center gap-3">
-                    <div className="rounded-full bg-sky-500/20 px-3 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-sky-200">
-                      Scrum Book
-                    </div>
-                    <div className="hidden flex-col text-left sm:flex">
-                      <span className="text-sm font-semibold text-slate-200">Your Rugby League Companion</span>
-                      <span className="text-xs text-slate-400">Track fixtures, grounds, badges &amp; more.</span>
-                    </div>
-                  </Link>
-                  <nav className="hidden items-center gap-2 text-sm font-semibold text-slate-300 md:flex">
-                    {primaryNavigation.map((item) => (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        className="rounded-full px-4 py-2 transition-colors hover:bg-slate-800/70 hover:text-white"
-                      >
-                        {item.label}
-                      </Link>
-                    ))}
-                  </nav>
-                  <div className="flex items-center gap-3">
-                    <Link
-                      href="/league-table"
-                      className="rounded-full border border-sky-400/40 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-100 shadow-lg shadow-sky-900/40 transition-colors hover:border-sky-400 hover:bg-sky-500/30"
-                    >
-                      View Standings
-                    </Link>
+        <div className="relative min-h-screen overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(30,64,175,0.35),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(6,182,212,0.25),_transparent_55%)]" aria-hidden="true" />
+          <div className="relative flex min-h-screen flex-col">
+            <header className="border-b border-white/10 bg-slate-950/80 backdrop-blur">
+              <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 py-5 sm:px-6 lg:px-8">
+                <Link href="/" className="flex items-center gap-3">
+                  <div className="rounded-full bg-sky-500/20 px-3 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-sky-200">
+                    Scrum Book
                   </div>
-                </div>
-              </header>
-              <div className="border-b border-white/5 bg-slate-950/60 py-3 text-sm text-slate-300 md:hidden">
-                <div className="mx-auto flex max-w-6xl items-center justify-center gap-3 px-5 sm:px-6">
+                  <div className="hidden flex-col text-left sm:flex">
+                    <span className="text-sm font-semibold text-slate-200">Your Rugby League Companion</span>
+                    <span className="text-xs text-slate-400">Track fixtures, grounds, badges &amp; more.</span>
+                  </div>
+                </Link>
+                <nav className="hidden items-center gap-2 text-sm font-semibold text-slate-300 md:flex">
                   {primaryNavigation.map((item) => (
                     <Link
-                      key={`mobile-${item.href}`}
+                      key={item.href}
                       href={item.href}
-                      className="rounded-full bg-slate-800/70 px-4 py-2 transition-colors hover:bg-slate-700 hover:text-white"
+                      className="rounded-full px-4 py-2 transition-colors hover:bg-slate-800/70 hover:text-white"
                     >
                       {item.label}
                     </Link>
                   ))}
+                </nav>
+                <div className="flex items-center gap-3">
+                  <Link
+                    href="/league-table"
+                    className="rounded-full border border-sky-400/40 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-100 shadow-lg shadow-sky-900/40 transition-colors hover:border-sky-400 hover:bg-sky-500/30"
+                  >
+                    View Standings
+                  </Link>
                 </div>
               </div>
-              <main className="flex-1">
-                <div className="mx-auto w-full max-w-6xl px-5 py-12 sm:px-6 lg:px-8">
-                  <div className="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-[0_20px_60px_-25px_rgba(15,118,110,0.65)] backdrop-blur md:p-10">
-                    {children}
-                  </div>
-                </div>
-              </main>
-              <footer className="border-t border-white/10 bg-slate-950/80">
-                <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-5 py-8 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-                  <div>
-                    <p className="font-semibold text-slate-200">The Scrum Book</p>
-                    <p className="text-xs text-slate-400">Built for dedicated rugby league fans everywhere.</p>
-                  </div>
-                  <p className="text-xs text-slate-500">&copy; {new Date().getFullYear()} The Scrum Book. All rights reserved.</p>
-                </div>
-              </footer>
+            </header>
+            <div className="border-b border-white/5 bg-slate-950/60 py-3 text-sm text-slate-300 md:hidden">
+              <div className="mx-auto flex max-w-6xl items-center justify-center gap-3 px-5 sm:px-6">
+                {primaryNavigation.map((item) => (
+                  <Link
+                    key={`mobile-${item.href}`}
+                    href={item.href}
+                    className="rounded-full bg-slate-800/70 px-4 py-2 transition-colors hover:bg-slate-700 hover:text-white"
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
             </div>
+            <main className="flex-1">
+              <div className="mx-auto w-full max-w-6xl px-5 py-12 sm:px-6 lg:px-8">
+                <div className="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-[0_20px_60px_-25px_rgba(15,118,110,0.65)] backdrop-blur md:p-10">
+                  {children}
+                </div>
+              </div>
+            </main>
+            <footer className="border-t border-white/10 bg-slate-950/80">
+              <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-5 py-8 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+                <div>
+                  <p className="font-semibold text-slate-200">The Scrum Book</p>
+                  <p className="text-xs text-slate-400">Built for dedicated rugby league fans everywhere.</p>
+                </div>
+                <p className="text-xs text-slate-500">&copy; {new Date().getFullYear()} The Scrum Book. All rights reserved.</p>
+              </div>
+            </footer>
           </div>
-        </Providers>
+        </div>
       </body>
     </html>
   );

--- a/the-scrum-book-nextjs/src/app/page.tsx
+++ b/the-scrum-book-nextjs/src/app/page.tsx
@@ -1,105 +1,294 @@
-import Image from "next/image";
+'use client';
 
-export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
-        <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Get started by editing&nbsp;
-          <code className="font-mono font-bold">src/app/page.tsx</code>
-        </p>
-        <div className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:h-auto lg:w-auto lg:bg-none">
-          <a
-            className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            By{' '}
-            <Image
-              src="/vercel.svg"
-              alt="Vercel Logo"
-              className="dark:invert"
-              width={100}
-              height={24}
-              priority
-            />
-          </a>
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Providers } from './providers';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { Header } from '@/components/Header';
+import { MobileNav } from '@/components/MobileNav';
+import { MatchList } from '@/components/MatchList';
+import { MyMatchesView } from '@/components/MyMatchesView';
+import { AboutView } from '@/components/AboutView';
+import { BadgesView } from '@/components/BadgesView';
+import { StatsView } from '@/components/StatsView';
+import { GroundsView, LeagueTableView } from '@/components/LeagueTableView';
+import { LoadingSpinner } from '@/components/LoadingSpinner';
+import { ErrorDisplay } from '@/components/ErrorDisplay';
+import { MatchdayView } from '@/components/MatchdayView';
+import { ProfileView } from '@/components/ProfileView';
+import { TeamStatsView } from '@/components/TeamStatsView';
+import { NearbyMatchesView } from '@/components/NearbyMatchesView';
+import { DataUploader } from '@/components/DataUploader';
+import { CommunityView } from '@/components/CommunityView';
+import { LoginPromptView } from '@/components/LoginPromptView';
+import { DesktopTopBar } from '@/components/DesktopTopBar';
+import { MobileBottomBar } from '@/components/MobileBottomBar';
+import { LogoIcon, MenuIcon } from '@/components/Icons';
+import type { Match, View } from '@/types';
+import { fetchMatches } from '@/services/apiService';
+import { allBadges } from '@/badges';
+import { useTheme } from '@/hooks/useTheme';
+import { syncThemeWithFavouriteTeam } from '@/utils/themeUtils';
+
+const protectedViews: View[] = ['MY_MATCHES', 'STATS', 'BADGES', 'PROFILE', 'COMMUNITY', 'ADMIN'];
+const VIEW_STORAGE_KEY = 'scrum-book:last-view';
+const allViews: View[] = [
+  'UPCOMING',
+  'MATCH_DAY',
+  'LEAGUE_TABLE',
+  'GROUNDS',
+  'MY_MATCHES',
+  'STATS',
+  'ABOUT',
+  'BADGES',
+  'PROFILE',
+  'TEAM_STATS',
+  'NEARBY',
+  'PREDICTION_GAMES',
+  'ADMIN',
+  'COMMUNITY',
+];
+
+const isValidView = (value: string | null): value is View => typeof value === 'string' && allViews.includes(value as View);
+
+const MainApp = () => {
+  const [view, setView] = useState<View>(() => {
+    if (typeof window === 'undefined') {
+      return 'PROFILE';
+    }
+
+    const storedView = window.localStorage.getItem(VIEW_STORAGE_KEY);
+    if (isValidView(storedView)) {
+      return storedView;
+    }
+
+    return 'PROFILE';
+  });
+  const [theme] = useTheme();
+  const themeMode = theme === 'dark' ? 'dark' : 'light';
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+
+  const {
+    currentUser,
+    profile,
+    loading: authLoading,
+    login,
+    loginWithCredentials,
+    signup,
+    requestPasswordReset,
+    logout,
+    addAttendedMatch,
+    removeAttendedMatch,
+    updateUser,
+  } = useAuth();
+
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const initialLoadStarted = useRef(false);
+  const favouriteTeamId = profile?.user.favoriteTeamId;
+
+  const loadAppData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const fetchedMatches = await fetchMatches();
+      setMatches(fetchedMatches);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to fetch initial application data. Please check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialLoadStarted.current) {
+      initialLoadStarted.current = true;
+      loadAppData();
+    }
+  }, [loadAppData]);
+
+  useEffect(() => {
+    syncThemeWithFavouriteTeam(favouriteTeamId, themeMode);
+  }, [favouriteTeamId, themeMode]);
+
+  const handleAttend = (match: Match) => {
+    if (!currentUser) {
+      setView('PROFILE');
+    } else {
+      addAttendedMatch(match);
+    }
+  };
+
+  const handleUnattend = (matchId: string) => {
+    if (!currentUser) {
+      setView('PROFILE');
+    } else {
+      removeAttendedMatch(matchId);
+    }
+  };
+
+  const shouldShowLoginPrompt = !currentUser && protectedViews.includes(view);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(VIEW_STORAGE_KEY, view);
+    }
+  }, [view]);
+
+  useEffect(() => {
+    if (shouldShowLoginPrompt) {
+      setIsMobileNavOpen(false);
+    }
+  }, [shouldShowLoginPrompt]);
+
+  const renderContent = () => {
+    if (error) {
+      return <ErrorDisplay message={error} onRetry={loadAppData} />;
+    }
+
+    if (loading && !error) {
+      return (
+        <div className="flex flex-col items-center justify-center h-64">
+          <LoadingSpinner />
+          <p className="mt-4 text-text-subtle">Fetching season fixtures...</p>
         </div>
-      </div>
+      );
+    }
 
-      <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-[480px] before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:from-transparent before:dark:via-sky-900 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px]">
-        <Image
-          className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70]"
-          src="/next.svg"
-          alt="Next.js Logo"
-          width={180}
-          height={37}
-          priority
+    if (shouldShowLoginPrompt) {
+      return (
+        <LoginPromptView
+          onLogin={login}
+          onEmailLogin={loginWithCredentials}
+          onSignup={signup}
+          onPasswordReset={requestPasswordReset}
+          theme={themeMode}
         />
-      </div>
+      );
+    }
 
-      <div className="mb-32 grid text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:grid-cols-4 lg:text-left">
-        <a
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Docs{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">-&gt;</span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Find in-depth information about Next.js features and API.
-          </p>
-        </a>
+    if (authLoading && protectedViews.includes(view)) {
+      return (
+        <div className="flex flex-col items-center justify-center h-64">
+          <LoadingSpinner />
+          <p className="mt-4 text-text-subtle">Connecting...</p>
+        </div>
+      );
+    }
 
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Learn{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">-&gt;</span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Learn about Next.js in an interactive course with&nbsp;quizzes!
-          </p>
-        </a>
+    const attendedMatchIds = profile?.attendedMatches.map((attendedMatch) => attendedMatch.match.id) || [];
 
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Templates{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">-&gt;</span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Explore starter templates for Next.js.
-          </p>
-        </a>
+    switch (view) {
+      case 'UPCOMING':
+        return (
+          <MatchList matches={matches} attendedMatchIds={attendedMatchIds} onAttend={handleAttend} onRefresh={loadAppData} />
+        );
+      case 'NEARBY':
+        return (
+          <NearbyMatchesView matches={matches} attendedMatchIds={attendedMatchIds} onAttend={handleAttend} />
+        );
+      case 'MATCH_DAY':
+        return <MatchdayView matches={matches} attendedMatchIds={attendedMatchIds} onAttend={handleAttend} />;
+      case 'LEAGUE_TABLE':
+        return <LeagueTableView />;
+      case 'TEAM_STATS':
+        return <TeamStatsView />;
+      case 'GROUNDS':
+        return <GroundsView />;
+      case 'ABOUT':
+        return <AboutView theme={themeMode} />;
+      case 'MY_MATCHES':
+        return profile ? (
+          <MyMatchesView attendedMatches={profile.attendedMatches} onRemove={handleUnattend} />
+        ) : (
+          <LoadingSpinner />
+        );
+      case 'STATS':
+        return profile ? <StatsView user={profile.user} attendedMatches={profile.attendedMatches} /> : <LoadingSpinner />;
+      case 'BADGES':
+        return profile ? <BadgesView allBadges={allBadges} earnedBadgeIds={profile.earnedBadgeIds} /> : <LoadingSpinner />;
+      case 'COMMUNITY':
+        return <CommunityView />;
+      case 'PROFILE':
+        return profile ? (
+          <ProfileView
+            user={profile.user}
+            setUser={(updatedUser) => updateUser(updatedUser)}
+            setView={setView}
+            attendedMatches={profile.attendedMatches}
+            earnedBadgeIds={profile.earnedBadgeIds}
+            onLogout={logout}
+          />
+        ) : (
+          <LoadingSpinner />
+        );
+      case 'ADMIN':
+        return <DataUploader />;
+      default:
+        return (
+          <MatchList matches={matches} attendedMatchIds={attendedMatchIds} onAttend={handleAttend} onRefresh={loadAppData} />
+        );
+    }
+  };
 
-        <a
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:hover:border-neutral-700 dark:hover:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Deploy{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">-&gt;</span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Instantly deploy your Next.js site to a shareable URL with Vercel.
-          </p>
-        </a>
-      </div>
-    </main>
+  const mainBaseClasses = 'mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8';
+  const mainSpacing = shouldShowLoginPrompt ? 'py-16 md:py-20 flex items-center justify-center' : 'pt-24 md:pt-28 pb-28 md:pb-16';
+
+  return (
+    <div className="min-h-screen font-sans text-text app-background">
+      {!shouldShowLoginPrompt ? (
+        <>
+          <DesktopTopBar currentView={view} setView={setView} />
+          <Header
+            setView={setView}
+            theme={theme}
+            isMobileNavOpen={isMobileNavOpen}
+            onMobileNavToggle={() => setIsMobileNavOpen((open) => !open)}
+          />
+          <button
+            type="button"
+            className="hidden md:flex fixed top-6 right-6 z-40 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
+            onClick={() => setIsMobileNavOpen(true)}
+            aria-label="Open navigation menu"
+          >
+            <MenuIcon className="w-5 h-5" />
+            <span>Menu</span>
+          </button>
+        </>
+      ) : null}
+      <main className={`${mainBaseClasses} ${mainSpacing}`}>
+        {shouldShowLoginPrompt ? <div className="w-full">{renderContent()}</div> : <div className="space-y-8">{renderContent()}</div>}
+      </main>
+      {!shouldShowLoginPrompt ? (
+        <>
+          <MobileNav
+            currentView={view}
+            setView={setView}
+            currentUser={currentUser}
+            isOpen={isMobileNavOpen}
+            onClose={() => setIsMobileNavOpen(false)}
+            theme={themeMode}
+            onLogout={logout}
+          />
+          <MobileBottomBar currentView={view} setView={setView} />
+          <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface/70 backdrop-blur">
+            <LogoIcon className="w-12 h-12 mx-auto mb-3" theme={themeMode} />
+            <p className="font-semibold text-text">The Scrum Book</p>
+            <p className="mt-1">Your ultimate rugby league companion. Track matches, earn badges, and connect with other fans.</p>
+          </footer>
+        </>
+      ) : null}
+    </div>
   );
-}
+};
+
+const HomePage = () => (
+  <Providers>
+    <AuthProvider>
+      <MainApp />
+    </AuthProvider>
+  </Providers>
+);
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- migrate the legacy React App component logic into the Next.js App Router home page wrapped in the shared Providers and AuthProvider
- keep the existing Next.js layout styling while allowing the new page component to supply the React Query/Auth context stack

## Testing
- npm run lint *(fails: `next` executable not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e34b6b2c832ca5d92d310d05a5be