### PR TITLE
Configure Jest and React Testing Library

### DIFF
--- a/the-scrum-book-nextjs/jest.config.js
+++ b/the-scrum-book-nextjs/jest.config.js
@@ -1,0 +1,17 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/the-scrum-book-nextjs/jest.setup.js
+++ b/the-scrum-book-nextjs/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/the-scrum-book-nextjs/package.json
+++ b/the-scrum-book-nextjs/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.7",
@@ -19,9 +20,15 @@
     "@types/node": "20.12.7",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "@testing-library/jest-dom": "^6.4.3",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.3",
     "typescript": "5.4.5"


### PR DESCRIPTION
## Summary
- add a Jest configuration based on next/jest with a shared setup file
- register React Testing Library helpers and align module path aliases
- update package scripts and devDependencies to support running unit tests

## Testing
- not run (Jest dependencies could not be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0e8eb25a8832ca9bd308b9015ec1d