### PR TITLE
Add Node test coverage for TeamLogo and formatDateUK

### DIFF
--- a/the-scrum-book-nextjs/package.json
+++ b/the-scrum-book-nextjs/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --require ./tests/register.js --test tests/utils/formatDateUK.test.ts tests/components/TeamLogo.test.tsx"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.7",

--- a/the-scrum-book-nextjs/tests/components/TeamLogo.test.tsx
+++ b/the-scrum-book-nextjs/tests/components/TeamLogo.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { TeamLogo } from '../../src/components/TeamLogo';
+
+describe('TeamLogo', () => {
+  it('renders initials and gradient for known teams', () => {
+    const markup = renderToStaticMarkup(
+      <TeamLogo teamId="3" teamName="Leeds Rhinos" />
+    );
+
+    assert(markup.includes('>LR<'), `expected initials to be present in markup: ${markup}`);
+    assert(
+      markup.includes('linear-gradient(135deg, #00539F, #FFB81C)'),
+      `expected palette gradient in markup: ${markup}`
+    );
+  });
+
+  it('falls back to default styling when branding is missing', () => {
+    const markup = renderToStaticMarkup(
+      <TeamLogo teamId="unknown" teamName="Mystery Team" />
+    );
+
+    assert(markup.includes('>MT<'), `expected fallback initials in markup: ${markup}`);
+    assert(
+      markup.includes('linear-gradient(135deg, #6B7280, #9CA3AF)'),
+      `expected fallback gradient in markup: ${markup}`
+    );
+    assert(
+      markup.includes('color:#FFFFFF') || markup.includes('color:#ffffff'),
+      `expected fallback text colour in markup: ${markup}`
+    );
+  });
+});

--- a/the-scrum-book-nextjs/tests/register.js
+++ b/the-scrum-book-nextjs/tests/register.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+const ts = require('typescript');
+
+const projectRoot = path.resolve(__dirname, '..');
+
+const compilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2019,
+  jsx: ts.JsxEmit.ReactJSX,
+  esModuleInterop: true,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  resolveJsonModule: true,
+  allowSyntheticDefaultImports: true,
+};
+
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith('@/')) {
+    const resolved = path.join(projectRoot, 'src', request.slice(2));
+    return originalResolveFilename.call(this, resolved, parent, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+const compile = (module, filename) => {
+  const source = fs.readFileSync(filename, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions,
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+Module._extensions['.ts'] = compile;
+Module._extensions['.tsx'] = compile;

--- a/the-scrum-book-nextjs/tests/utils/formatDateUK.test.ts
+++ b/the-scrum-book-nextjs/tests/utils/formatDateUK.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatDateUK } from '../../src/utils/date';
+
+describe('formatDateUK', () => {
+  it('formats Date instances using UK locale order', () => {
+    const date = new Date(Date.UTC(2024, 0, 15, 12));
+    assert.equal(formatDateUK(date), '15/01/2024');
+  });
+
+  it('formats numeric timestamps', () => {
+    const timestamp = Date.UTC(2023, 10, 5, 12);
+    assert.equal(formatDateUK(timestamp), '05/11/2023');
+  });
+
+  it('returns an empty string for invalid inputs', () => {
+    assert.equal(formatDateUK('not-a-date'), '');
+  });
+});


### PR DESCRIPTION
## Summary
- add a custom Node test runner setup that transpiles TypeScript/TSX and understands the @/ alias
- add unit tests for the formatDateUK helper covering valid and invalid inputs
- add a TeamLogo component test that verifies initials and gradient styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0e9782d84832cb8bc814b54b98ed4