### PR TITLE
Add Zod validation for attended match endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const cors = require('cors');
+const admin = require('firebase-admin');
+const { z } = require('zod');
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+if (!admin.apps.length) {
+  if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+    const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount)
+    });
+  } else {
+    admin.initializeApp();
+  }
+}
+
+const db = admin.firestore();
+
+const attendedMatchSchema = z.object({
+  matchId: z
+    .string({ required_error: 'matchId is required' })
+    .trim()
+    .min(1, 'matchId must be a non-empty string')
+});
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+app.get('/api/matches', async (req, res) => {
+  try {
+    const snapshot = await db.collection('matches').get();
+    const matches = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(matches);
+  } catch (error) {
+    console.error('Error fetching matches:', error);
+    res.status(500).json({ error: 'Failed to fetch matches' });
+  }
+});
+
+app.get('/api/league-table', async (req, res) => {
+  try {
+    const snapshot = await db.collection('leagueTable').get();
+    const leagueTable = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(leagueTable);
+  } catch (error) {
+    console.error('Error fetching league table:', error);
+    res.status(500).json({ error: 'Failed to fetch league table' });
+  }
+});
+
+app.get('/api/users/:userId/profile', async (req, res) => {
+  const { userId } = req.params;
+
+  try {
+    const userDoc = await db.collection('users').doc(userId).get();
+
+    if (!userDoc.exists) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    res.json({ id: userDoc.id, ...userDoc.data() });
+  } catch (error) {
+    console.error(`Error fetching profile for user ${userId}:`, error);
+    res.status(500).json({ error: 'Failed to fetch user profile' });
+  }
+});
+
+app.post('/api/users/:userId/attended-matches', async (req, res) => {
+  const { userId } = req.params;
+  const result = attendedMatchSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json({
+      error: 'Invalid request body',
+      details: result.error.issues.map((issue) => ({
+        message: issue.message,
+        path: issue.path
+      }))
+    });
+  }
+
+  const { matchId } = result.data;
+
+  try {
+    const userRef = db.collection('users').doc(userId);
+
+    await userRef.set(
+      {
+        attendedMatches: admin.firestore.FieldValue.arrayUnion(matchId)
+      },
+      { merge: true }
+    );
+
+    res.status(200).json({ matchId });
+  } catch (error) {
+    console.error(`Error updating attended matches for user ${userId}:`, error);
+    res.status(500).json({ error: 'Failed to update attended matches' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "API server for The Scrum Book",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "firebase-admin": "^12.6.0",
+    "zod": "^3.23.8"
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express server package with dependencies including Zod
- create the attended match endpoint with schema validation using Zod and Firestore array updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0eab6a8cc832ca8c11faeb0bfed32