### PR TITLE
Fix hero background path for deployment

### DIFF
--- a/the-scrum-book-nextjs/src/components/ProfileView.module.css
+++ b/the-scrum-book-nextjs/src/components/ProfileView.module.css
@@ -24,7 +24,12 @@
 .heroBackdrop {
   position: absolute;
   inset: 0;
-  background-image: url('../background.png');
+  /*
+    Use the public asset so the deployed site resolves the background
+    correctly. Relative paths inside CSS modules point to the module
+    directory, which breaks once the app is built and deployed.
+  */
+  background-image: url('/background.png');
   background-repeat: no-repeat;
   background-size: 70%;
   background-position: left top;


### PR DESCRIPTION
## Summary
- point the hero backdrop CSS to the public/background.png asset so Firebase Hosting serves the correct image
- add documentation in the stylesheet explaining why the public path is required for deployed builds

## Testing
- npm install *(fails: 403 Forbidden fetching @sentry/react from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e111e5786c832c9113d2dd2349bda3