### PR TITLE
Use background image in app layout

### DIFF
--- a/the-scrum-book-nextjs/src/app/globals.css
+++ b/the-scrum-book-nextjs/src/app/globals.css
@@ -53,8 +53,11 @@ body {
   It applies the dynamic gradients as a background.
 */
 .app-background {
-    background-image: var(--gradient-1), var(--gradient-2), var(--gradient-3);
-    background-color: var(--clr-surface);
+  background-image: var(--gradient-1), var(--gradient-2), var(--gradient-3), url('/background.png');
+  background-color: var(--clr-surface);
+  background-repeat: no-repeat, no-repeat, no-repeat, no-repeat;
+  background-size: auto, auto, auto, cover;
+  background-position: center, center, center, center;
 }
 
 a {


### PR DESCRIPTION
## Summary
- update the shared app background utility to layer the background.png asset beneath the existing gradients
- ensure the background image covers the viewport without tiling while retaining current gradient overlays

## Testing
- npm run lint *(fails: next not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a2fec28832cbbdd83689ecbaf20