### PR TITLE
Update Hull KR vs St Helens match result

### DIFF
--- a/the-scrum-book-nextjs/src/services/mockData.ts
+++ b/the-scrum-book-nextjs/src/services/mockData.ts
@@ -424,10 +424,10 @@ export const mockMatches: Match[] = [
     114,
     TEAMS.hullKR,
     TEAMS.stHelens,
-    'SCHEDULED',
+    'FULL-TIME',
     new Date('2025-10-04T17:30:00+01:00'),
-    0,
-    0,
+    20,
+    12,
     teamIdToVenue[TEAMS.hullKR.id]
   ),
   createMatchOnDate(


### PR DESCRIPTION
## Summary
- update the mock Super League fixture between Hull KR and St Helens to show the full-time result

## Testing
- `npm run lint` *(fails: repository package.json contains non-standard whitespace so npm cannot parse it)*

------
https://chatgpt.com/codex/tasks/task_e_68e180653020832cbd8509e1a28ccb8b