### PR TITLE
feat: add PWA support

### DIFF
--- a/the-scrum-book-nextjs/public/sw.js
+++ b/the-scrum-book-nextjs/public/sw.js
@@ -1,0 +1,71 @@
+const CACHE_NAME = "scrum-book-cache-v1";
+const ASSETS_TO_CACHE = [
+  "/",
+  "/manifest.webmanifest",
+  "/icon-192x192.png",
+  "/icon-512x512.png",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS_TO_CACHE))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames.map((cacheName) => {
+            if (cacheName !== CACHE_NAME) {
+              return caches.delete(cacheName);
+            }
+            return Promise.resolve(false);
+          })
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        if (response.ok) {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, responseClone);
+          });
+        }
+        return response;
+      })
+      .catch(() =>
+        caches.match(event.request).then((cached) => {
+          if (cached) {
+            return cached;
+          }
+
+          if (event.request.mode === "navigate") {
+            return caches.match("/");
+          }
+
+          return Response.error();
+        })
+      )
+  );
+});

--- a/the-scrum-book-nextjs/src/app/layout.tsx
+++ b/the-scrum-book-nextjs/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Roboto, Barlow_Condensed } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { SentryErrorBoundary } from "./SentryErrorBoundary";
+import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 
 // Initialize Roboto with a more descriptive variable name
 const roboto = Roboto({
@@ -21,6 +22,20 @@ export const metadata: Metadata = {
   title: "The Scrum Book",
   description:
     "Your ultimate rugby league companion for fixtures, stats, and matchday planning.",
+  applicationName: "The Scrum Book",
+  manifest: "/manifest.webmanifest",
+  themeColor: "#0c4b5a",
+  icons: [
+    { rel: "icon", url: "/favicon.ico" },
+    { rel: "icon", url: "/icon-192x192.png", sizes: "192x192" },
+    { rel: "icon", url: "/icon-512x512.png", sizes: "512x512" },
+    { rel: "apple-touch-icon", url: "/icon-192x192.png" },
+  ],
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "The Scrum Book",
+  },
 };
 
 export default function RootLayout({
@@ -31,6 +46,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
       <body className={`${roboto.variable} ${barlowCondensed.variable} h-full font-sans antialiased`}>
+        <ServiceWorkerRegister />
         <SentryErrorBoundary>{children}</SentryErrorBoundary>
       </body>
     </html>

--- a/the-scrum-book-nextjs/src/app/manifest.ts
+++ b/the-scrum-book-nextjs/src/app/manifest.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "The Scrum Book",
+    short_name: "Scrum Book",
+    description:
+      "Your ultimate rugby league companion for fixtures, stats, and matchday planning.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0c4b5a",
+    theme_color: "#0c4b5a",
+    orientation: "portrait-primary",
+    scope: "/",
+    icons: [
+      {
+        src: "/icon-192x192.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any maskable",
+      },
+      {
+        src: "/icon-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any maskable",
+      },
+    ],
+  };
+}

--- a/the-scrum-book-nextjs/src/components/ServiceWorkerRegister.tsx
+++ b/the-scrum-book-nextjs/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      process.env.NODE_ENV !== "production"
+    ) {
+      return;
+    }
+
+    const register = async () => {
+      try {
+        await navigator.serviceWorker.register("/sw.js", { scope: "/" });
+      } catch (error) {
+        console.error("Service worker registration failed", error);
+      }
+    };
+
+    register();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- configure the global layout metadata with manifest details, install icons, and service worker registration so the app can be installed as a PWA
- add a Next.js manifest route and offline-aware service worker with precached core assets to satisfy PWA requirements
- remove the placeholder icon binaries so the final assets can be provided manually

## Testing
- npm run lint *(fails: next binary is not available in the execution environment without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e16af10c68832cb36d86f5f713c0f4