### PR TITLE
feat: show fallback data warnings when Firestore is unreachable

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -88,6 +88,7 @@ const respondWithMockData = (res, collection, error) => {
     console.info(`Firestore not configured. Serving mock ${collection} data.`);
   }
 
+  res.set('x-data-source', 'mock');
   const payload = collection === 'matches' ? getMockMatches() : getMockLeagueTable();
   res.status(200).json(payload);
 };
@@ -124,6 +125,7 @@ app.get('/api/matches', async (req, res) => {
     async () => {
       const snapshot = await db.collection('matches').get();
       const matches = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      res.set('x-data-source', 'firestore');
       res.json(matches);
     },
     (error) => respondWithMockData(res, 'matches', error)
@@ -137,6 +139,7 @@ app.get('/api/league-table', async (req, res) => {
     async () => {
       const snapshot = await db.collection('leagueTable').get();
       const leagueTable = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      res.set('x-data-source', 'firestore');
       res.json(leagueTable);
     },
     (error) => respondWithMockData(res, 'league table', error)


### PR DESCRIPTION
## Summary
- track whether the frontend receives live Firestore data or seeded fixtures
- surface a seeded-data notice on the home dashboard and league table when mocks are used
- add matching x-data-source headers in the Express API so the client can detect fallbacks

## Testing
- Not run (npm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68e1a56d2080832cafb46530699e9175