### PR TITLE
Fix Firebase workflows to install Next.js app dependencies

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,8 +9,17 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: the-scrum-book-nextjs
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
       - name: Run Security Audit
         run: npm audit --audit-level=high  # Fail if any high-severity vulnerabilities are detected
       - name: Build project

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,8 +11,17 @@ jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: the-scrum-book-nextjs
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: the-scrum-book-nextjs
 
     steps:
       - name: Check out repository
@@ -23,6 +26,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- run all GitHub Actions workflow commands from the Next.js app directory so npm can find the lockfile
- set up Node.js 20 with npm caching that targets the app's package-lock in each Firebase Hosting workflow

## Testing
- npm ci *(fails in CI due to missing auth for @sentry/react when run locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b7e4717c832ca20a3acfa70f913f