### PR TITLE
Run Firebase workflows from Next.js app directory

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,10 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: the-scrum-book-nextjs
       - name: Run Security Audit
         run: npm audit --audit-level=high  # Fail if any high-severity vulnerabilities are detected
+        working-directory: the-scrum-book-nextjs
       - name: Build project
-        run: npm ci && npm run build
+        run: npm run build
+        working-directory: the-scrum-book-nextjs
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,7 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm ci && npm run build
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: the-scrum-book-nextjs
+      - name: Build project
+        run: npm run build
+        working-directory: the-scrum-book-nextjs
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -23,12 +22,15 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
 
       - name: Install dependencies
         run: npm ci
+        working-directory: the-scrum-book-nextjs
 
       - name: Build project
         run: npm run build
+        working-directory: the-scrum-book-nextjs
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
## Summary
- run npm install/build steps from the Next.js app directory in each Firebase Hosting workflow
- add explicit dependency installation before audits and builds to ensure commands operate on the app lockfile

## Testing
- not run (npm ci requires access to @sentry/react in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1b7e4717c832ca20a3acfa70f913f