### PR TITLE
Add staging Firebase Hosting deployment workflow

### DIFF
--- a/.github/workflows/firebase-hosting-staging.yml
+++ b/.github/workflows/firebase-hosting-staging.yml
@@ -1,0 +1,43 @@
+name: Deploy staging to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - staging
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: the-scrum-book-nextjs
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting (staging)
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_THE_SCRUM_BOOK }}
+          projectId: the-scrum-book
+          channelId: staging-site
+          expires: '7d'


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the staging branch to a persistent Firebase Hosting channel
- build the Next.js project with Node 20 before deploying and reuse the existing Firebase service account secret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e216e312b0832cb2714a95093d657f