### PR TITLE
feat: rebrand app to The Turnstile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 ```md
-# The Scrum Book
+# The Turnstile - The Rugby League Matchday Companion
 
-![The Scrum Book logo](public/logo.png)
+![The Turnstile logo](public/logo.png)
 
-The Scrum Book is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
+The Turnstile is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
 
 ---
 
@@ -12,7 +12,7 @@ The Scrum Book is a modern React + Vite application that helps rugby league fans
 
 - **Match Browser** — search and filter the full season fixture list and mark games you attended.
 - **Match Day dashboards** — jump to the fixtures happening soon or near you with tailored views.
-- **My Scrum Book** — track total matches, unique venues, and revisit the games you have already logged.
+- **My Turnstile Log** — track total matches, unique venues, and revisit the games you have already logged.
 - **Offline-friendly seed data** — local fixtures and venues power the UI until you wire up Firestore.
 
 ---
@@ -183,7 +183,7 @@ This repository includes a GitHub Actions workflow (`.github/workflows/firebase-
 1. Create a Firebase service account with the **Firebase Hosting Admin** role and download the JSON credentials file.
 2. In your GitHub repository settings, add the following secrets:
    - `FIREBASE_SERVICE_ACCOUNT` — the full JSON of the service account credentials.
-   - `FIREBASE_PROJECT_ID` — the target Firebase project ID (for example, `the-scrum-book`).
+    - `FIREBASE_PROJECT_ID` — the target Firebase project ID (for example, `the-turnstile`).
 3. Update `.firebaserc` so the `default` project matches the value of `FIREBASE_PROJECT_ID`.
 
 ---

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Scrum Book",
-   "description": "A web application for rugby league fans to track fixtures, log the games they've attended, and sync progress with Firebase when configured.",
+  "name": "The Turnstile",
+  "description": "A web application for rugby league fans to track fixtures, log the games they've attended, and sync progress with Firebase when configured.",
   "requestFramePermissions": []
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "the-scrum-book",
+  "name": "the-turnstile",
   "private": true,
   "version": "0.0.0",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "server",
   "version": "1.0.0",
-  "description": "API server for The Scrum Book",
+  "description": "API server for The Turnstile",
   "main": "index.js",
   "type": "commonjs",
   "scripts": {

--- a/the-scrum-book-nextjs/package.json
+++ b/the-scrum-book-nextjs/package.json
@@ -1,5 +1,5 @@
  {
-  "name": "the-scrum-book-nextjs",
+  "name": "the-turnstile-nextjs",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/the-scrum-book-nextjs/public/logo-dark.svg
+++ b/the-scrum-book-nextjs/public/logo-dark.svg
@@ -1,5 +1,5 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">The Scrum Book logo</title>
+  <title id="title">The Turnstile logo</title>
   <desc id="desc">A rugby ball icon on a midnight blue and crimson gradient circle.</desc>
   <defs>
     <linearGradient id="logoDarkGradient" x1="16" y1="16" x2="112" y2="112" gradientUnits="userSpaceOnUse">

--- a/the-scrum-book-nextjs/public/logo-light.svg
+++ b/the-scrum-book-nextjs/public/logo-light.svg
@@ -1,5 +1,5 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">The Scrum Book logo</title>
+  <title id="title">The Turnstile logo</title>
   <desc id="desc">A rugby ball icon on a crimson and gold gradient circle.</desc>
   <defs>
     <linearGradient id="logoLightGradient" x1="16" y1="16" x2="112" y2="112" gradientUnits="userSpaceOnUse">

--- a/the-scrum-book-nextjs/public/sw.js
+++ b/the-scrum-book-nextjs/public/sw.js
@@ -1,4 +1,4 @@
- const CACHE_NAME = "scrum-book-cache-v2"; // Changed from v1
+ const CACHE_NAME = "turnstile-cache-v1";
 
 const ASSETS_TO_CACHE = [
   "/",

--- a/the-scrum-book-nextjs/src/app/layout.tsx
+++ b/the-scrum-book-nextjs/src/app/layout.tsx
@@ -19,10 +19,10 @@ const barlowCondensed = Barlow_Condensed({
 });
 
 export const metadata: Metadata = {
-  title: "The Scrum Book",
+  title: "The Turnstile - The Rugby League Matchday Companion",
   description:
     "Your ultimate rugby league companion for fixtures, stats, and matchday planning.",
- applicationName: "The Scrum Book",
+  applicationName: "The Turnstile",
   manifest: "/manifest.webmanifest",
   themeColor: "#0c4b5a",
   icons: [
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
-    title: "The Scrum Book",
+    title: "The Turnstile",
   },
 };
 

--- a/the-scrum-book-nextjs/src/app/league-table/page.tsx
+++ b/the-scrum-book-nextjs/src/app/league-table/page.tsx
@@ -5,7 +5,7 @@ import { getServerFirestore } from "@/lib/firebaseAdmin";
 import { mockLeagueTable } from "@/services/mockData";
 
 export const metadata: Metadata = {
-  title: "Betfred Super League Table | The Scrum Book",
+  title: "Betfred Super League Table | The Turnstile",
   description: "Server-rendered snapshot of the latest Betfred Super League standings pulled directly from Firestore.",
 };
 

--- a/the-scrum-book-nextjs/src/app/manifest.ts
+++ b/the-scrum-book-nextjs/src/app/manifest.ts
@@ -2,8 +2,8 @@ import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "The Scrum Book",
-    short_name: "Scrum Book",
+    name: "The Turnstile - The Rugby League Matchday Companion",
+    short_name: "The Turnstile",
     description:
       "Your ultimate rugby league companion for fixtures, stats, and matchday planning.",
     start_url: "/",

--- a/the-scrum-book-nextjs/src/app/page.tsx
+++ b/the-scrum-book-nextjs/src/app/page.tsx
@@ -29,7 +29,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { syncThemeWithFavouriteTeam } from '@/utils/themeUtils';
 
 const protectedViews: View[] = ['MY_MATCHES', 'STATS', 'BADGES', 'PROFILE', 'COMMUNITY', 'ADMIN'];
-const VIEW_STORAGE_KEY = 'scrum-book:last-view';
+const VIEW_STORAGE_KEY = 'turnstile:last-view';
 const allViews: View[] = [
   'UPCOMING',
   'MATCH_DAY',
@@ -307,8 +307,8 @@ const MainApp = () => {
           <footer className="hidden md:block mt-6 rounded-3xl border border-border/70 bg-surface/80 px-10 py-8 text-center text-sm text-text-subtle/90 backdrop-blur-xl shadow-[0_35px_120px_-70px_rgba(11,29,58,0.9)]">
             <div className="flex flex-col items-center gap-2">
               <LogoIcon className="w-14 h-14" theme={themeMode} />
-              <p className="font-heading text-2xl tracking-[0.32em] uppercase text-text-strong">The Scrum Book</p>
-              <p className="text-base text-text">Your elite rugby league companion. Track fixtures, unlock supporter milestones, and own matchday.</p>
+              <p className="font-heading text-2xl tracking-[0.32em] uppercase text-text-strong">The Turnstile</p>
+              <p className="text-base text-text">The Rugby League Matchday Companion. Track fixtures, unlock supporter milestones, and own matchday.</p>
             </div>
           </footer>
         </>

--- a/the-scrum-book-nextjs/src/components/AboutView.tsx
+++ b/the-scrum-book-nextjs/src/components/AboutView.tsx
@@ -20,7 +20,7 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
           <div>
             <div className="mb-6 flex items-center gap-3 text-primary">
               <LogoIcon className="h-10 w-10" theme={theme} />
-              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Turnstile</span>
             </div>
             <h1 className="text-4xl font-bold text-text-strong md:text-5xl">{hero.title}</h1>
             <p className="mt-5 max-w-2xl text-lg text-text">{hero.description}</p>
@@ -155,9 +155,9 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
       </section>
 
       <section className="rounded-3xl border border-border/80 bg-surface-alt/80 p-8 text-center shadow-card">
-        <h2 className="text-2xl font-bold text-text-strong">Join The Scrum Book Community</h2>
+        <h2 className="text-2xl font-bold text-text-strong">Join The Turnstile Community</h2>
         <p className="mt-2 text-text">
-          Start building your fan legacy today. The Scrum Book is your home for all your rugby league memories and connections.
+          Start building your fan legacy today. The Turnstile is your home for all your rugby league memories and connections.
         </p>
         <p className="mt-4 text-sm font-medium uppercase tracking-[0.2em] text-text-subtle">
           Track. Share. Celebrate.

--- a/the-scrum-book-nextjs/src/components/DataUploader.tsx
+++ b/the-scrum-book-nextjs/src/components/DataUploader.tsx
@@ -15,7 +15,7 @@ export const DataUploader: React.FC = () => {
       </div>
 
       <p className="text-text-subtle mb-6">
-        The Scrum Book runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
+        The Turnstile runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
       </p>
 
       <div className="rounded-md border border-warning/30 bg-warning/10 p-4 text-warning flex items-center gap-3">

--- a/the-scrum-book-nextjs/src/components/Icons.tsx
+++ b/the-scrum-book-nextjs/src/components/Icons.tsx
@@ -26,7 +26,7 @@ export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', 
   return (
     <img
       src={resolvedSrc}
-      alt={alt ?? 'The Scrum Book logo'}
+      alt={alt ?? 'The Turnstile logo'}
       className={className}
       loading="lazy"
       style={{

--- a/the-scrum-book-nextjs/src/components/LoginPromptView.tsx
+++ b/the-scrum-book-nextjs/src/components/LoginPromptView.tsx
@@ -229,7 +229,7 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
           <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0px_15px_35px_rgba(3,19,31,0.45)]">
             <LogoIcon className="h-12 w-12 drop-shadow" theme={theme} />
           </div>
-          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Turnstile</p>
           <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
           <p className="mt-3 max-w-xs text-sm text-white/60">
             Sign in to manage your matchdays, track your stats, and stay connected with the rugby league community.

--- a/the-scrum-book-nextjs/src/components/MatchListItem.tsx
+++ b/the-scrum-book-nextjs/src/components/MatchListItem.tsx
@@ -138,7 +138,7 @@ export const MatchListItem: React.FC<MatchListItemProps> = ({ match, isAttended,
       title: 'Matchday Check-in',
       text: shareText,
       url: shareUrl,
-      clipboardFallbackText: `${shareText} Track every matchday with The Scrum Book: ${shareUrl}`,
+      clipboardFallbackText: `${shareText} Track every matchday with The Turnstile: ${shareUrl}`,
     });
 
     setShareFeedback(outcome);

--- a/the-scrum-book-nextjs/src/components/MobileNav.tsx
+++ b/the-scrum-book-nextjs/src/components/MobileNav.tsx
@@ -44,7 +44,7 @@ const primaryItems: NavItem[] = [
   { view: 'LEAGUE_TABLE', label: 'League Table', description: 'Track club standings', icon: TableCellsIcon },
   { view: 'GROUNDS', label: 'Grounds', description: 'Explore Super League stadiums', icon: BuildingStadiumIcon },
   { view: 'COMMUNITY', label: 'Community', description: 'Connect with fellow supporters', icon: UsersIcon },
-  { view: 'ABOUT', label: 'About', description: 'Learn about The Scrum Book', icon: InformationCircleIcon },
+  { view: 'ABOUT', label: 'About', description: 'Learn about The Turnstile', icon: InformationCircleIcon },
 ];
 
 const supporterItems: NavItem[] = [
@@ -94,7 +94,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({
             <div className="flex items-center gap-3">
               <LogoIcon className="h-10 w-10" theme={theme} />
               <div className="flex flex-col">
-                <span className="text-[11px] font-heading uppercase tracking-[0.4em] text-white/60">The Scrum Book</span>
+                <span className="text-[11px] font-heading uppercase tracking-[0.4em] text-white/60">The Turnstile</span>
                 <span className="text-xl font-heading uppercase tracking-[0.35em] text-white">Matchday Hub</span>
               </div>
             </div>

--- a/the-scrum-book-nextjs/src/components/StatsView.tsx
+++ b/the-scrum-book-nextjs/src/components/StatsView.tsx
@@ -81,7 +81,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
         if (!stats) return;
 
         const shareUrl = getAppShareUrl();
-        const shareText = `I've logged ${stats.totalMatches} matches, ${stats.totalGrounds} grounds and ${stats.totalPoints} total points this season on The Scrum Book.`;
+        const shareText = `I've logged ${stats.totalMatches} matches, ${stats.totalGrounds} grounds and ${stats.totalPoints} total points this season on The Turnstile.`;
 
         const outcome = await attemptShare({
             title: `${user.name}'s rugby league stats`,
@@ -121,7 +121,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
     return (
         <div className="space-y-6 text-text-strong">
              <div className="flex justify-between items-center gap-3">
-                <h1 className="text-xl font-bold">The Scrum Book</h1>
+                <h1 className="text-xl font-bold">The Turnstile</h1>
                 <div className="flex flex-col items-end gap-1">
                     <button
                         type="button"

--- a/the-scrum-book-nextjs/src/content/about.ts
+++ b/the-scrum-book-nextjs/src/content/about.ts
@@ -46,7 +46,7 @@ export const aboutContent: AboutContent = {
   hero: {
     title: 'Your Ultimate Rugby League Companion',
     description:
-      'The Scrum Book is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.',
+      'The Turnstile is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.',
     badges: [
       {
         icon: 'sparkles',
@@ -72,7 +72,7 @@ export const aboutContent: AboutContent = {
     {
       title: 'Your Digital Match Day Diary',
       description:
-        'The Scrum Book is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
+        'The Turnstile is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
       icon: 'sparkles',
       accent: 'from-primary/80 to-secondary/70',
       footer: 'Never forget a match day memory.',

--- a/the-scrum-book-nextjs/src/contexts/AuthContext.tsx
+++ b/the-scrum-book-nextjs/src/contexts/AuthContext.tsx
@@ -79,11 +79,11 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const LOCAL_PROFILE_KEY = 'scrum-book:profile';
-const LOCAL_AUTH_KEY = 'scrum-book:auth-user';
+const LOCAL_PROFILE_KEY = 'turnstile:profile';
+const LOCAL_AUTH_KEY = 'turnstile:auth-user';
 const GOOGLE_IDENTITY_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
-const LOCAL_ACCOUNTS_KEY = 'scrum-book:accounts';
-const LOCAL_PASSWORD_RESET_PREFIX = 'scrum-book:password-reset-requested';
+const LOCAL_ACCOUNTS_KEY = 'turnstile:accounts';
+const LOCAL_PASSWORD_RESET_PREFIX = 'turnstile:password-reset-requested';
 
 interface StoredAccount {
   id: string;
@@ -282,7 +282,7 @@ const createAccountId = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-  return `scrum-user-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `turnstile-user-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
 const loadGoogleIdentityServices = async (): Promise<GoogleIdentityServices> => {

--- a/the-scrum-book-nextjs/src/types.ts
+++ b/the-scrum-book-nextjs/src/types.ts
@@ -155,7 +155,7 @@ export interface Profile {
   predictions: Prediction[];
 }
 
-export interface ScrumBookData {
+export interface TurnstileData {
   profiles: Record<string, Profile>;
   activeProfileId: string | null;
 }

--- a/the-scrum-book-nextjs/src/utils/share.ts
+++ b/the-scrum-book-nextjs/src/utils/share.ts
@@ -52,5 +52,5 @@ export const getAppShareUrl = () => {
     return window.location.origin;
   }
 
-  return 'https://thescrumbook.com';
+  return 'https://theturnstile.com';
 };


### PR DESCRIPTION
## Summary
- update site copy, metadata, and manifests to use the new name "The Turnstile" and its full title
- refresh UI labels, share messaging, and asset metadata to highlight the new branding across components
- align local storage keys, cache identifiers, and config strings with the updated Turnstile branding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24ec11550832c8c3e98c93b7ae581