### PR TITLE
Update Turnstile logo assets

### DIFF
--- a/the-turnstile-nextjs/public/logo-dark.svg
+++ b/the-turnstile-nextjs/public/logo-dark.svg
@@ -1,24 +1,23 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">The Turnstile logo</title>
-  <desc id="desc">A rugby ball icon on a midnight blue and crimson gradient circle.</desc>
-  <defs>
-    <linearGradient id="logoDarkGradient" x1="16" y1="16" x2="112" y2="112" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0F172A" />
-      <stop offset="55%" stop-color="#7F1028" />
-      <stop offset="100%" stop-color="#FFD447" />
-    </linearGradient>
-    <linearGradient id="ballDark" x1="40" y1="40" x2="88" y2="88" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#F8FAFC" />
-      <stop offset="100%" stop-color="#E2E8F0" />
-    </linearGradient>
-  </defs>
-  <circle cx="64" cy="64" r="60" fill="url(#logoDarkGradient)" />
-  <g transform="rotate(-20 64 64)">
-    <ellipse cx="64" cy="64" rx="40" ry="28" fill="url(#ballDark)" stroke="#F8FAFC" stroke-width="4" />
-    <path d="M36 64h56" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round" />
-    <path d="M48 49l-6-12" stroke="#FFD447" stroke-width="4" stroke-linecap="round" />
-    <path d="M80 49l6-12" stroke="#FFD447" stroke-width="4" stroke-linecap="round" />
-    <path d="M48 79l-6 12" stroke="#FFD447" stroke-width="4" stroke-linecap="round" />
-    <path d="M80 79l6 12" stroke="#FFD447" stroke-width="4" stroke-linecap="round" />
+  <desc id="desc">A rugby ball encircled by two sweeping navy and teal arcs.</desc>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path
+      d="M38 95.5C24.7 83.1 19.9 64.4 25.8 47.2 32.6 27.4 50.8 14 72 14c17.5 0 33.8 9.2 43.1 24.3"
+      stroke="#1B3D63"
+      stroke-width="17"
+    />
+    <path
+      d="M90.4 30.8c13.6 12.5 19.1 31.3 13.4 49-6.7 21-25.4 34.7-45.7 34.7-17.7 0-34.1-10-42.8-25.7"
+      stroke="#3AD4E4"
+      stroke-width="17"
+    />
+  </g>
+  <g transform="rotate(-8 64 64)">
+    <ellipse cx="64" cy="64" rx="20" ry="28" fill="#F0F7FA" stroke="#D0E8F2" stroke-width="4" />
+    <path d="M48 64h32" stroke="#D0E8F2" stroke-width="4" stroke-linecap="round" />
+    <path d="M56 52v24" stroke="#6FE1F1" stroke-width="4" stroke-linecap="round" />
+    <path d="M64 50v28" stroke="#6FE1F1" stroke-width="4" stroke-linecap="round" />
+    <path d="M72 52v24" stroke="#6FE1F1" stroke-width="4" stroke-linecap="round" />
   </g>
 </svg>

--- a/the-turnstile-nextjs/public/logo-light.svg
+++ b/the-turnstile-nextjs/public/logo-light.svg
@@ -1,24 +1,23 @@
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">The Turnstile logo</title>
-  <desc id="desc">A rugby ball icon on a crimson and gold gradient circle.</desc>
-  <defs>
-    <linearGradient id="logoLightGradient" x1="16" y1="16" x2="112" y2="112" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#7F1028" />
-      <stop offset="50%" stop-color="#B71E3C" />
-      <stop offset="100%" stop-color="#FFD447" />
-    </linearGradient>
-    <linearGradient id="ballLight" x1="40" y1="40" x2="88" y2="88" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#FFFFFF" />
-      <stop offset="100%" stop-color="#F0F4FF" />
-    </linearGradient>
-  </defs>
-  <circle cx="64" cy="64" r="60" fill="url(#logoLightGradient)" />
-  <g transform="rotate(-20 64 64)">
-    <ellipse cx="64" cy="64" rx="40" ry="28" fill="url(#ballLight)" stroke="#1F2937" stroke-width="4" />
-    <path d="M36 64h56" stroke="#1F2937" stroke-width="4" stroke-linecap="round" />
-    <path d="M48 49l-6-12" stroke="#B71E3C" stroke-width="4" stroke-linecap="round" />
-    <path d="M80 49l6-12" stroke="#B71E3C" stroke-width="4" stroke-linecap="round" />
-    <path d="M48 79l-6 12" stroke="#B71E3C" stroke-width="4" stroke-linecap="round" />
-    <path d="M80 79l6 12" stroke="#B71E3C" stroke-width="4" stroke-linecap="round" />
+  <desc id="desc">A rugby ball encircled by two sweeping navy and teal arcs.</desc>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path
+      d="M38 95.5C24.7 83.1 19.9 64.4 25.8 47.2 32.6 27.4 50.8 14 72 14c17.5 0 33.8 9.2 43.1 24.3"
+      stroke="#0B2F4A"
+      stroke-width="17"
+    />
+    <path
+      d="M90.4 30.8c13.6 12.5 19.1 31.3 13.4 49-6.7 21-25.4 34.7-45.7 34.7-17.7 0-34.1-10-42.8-25.7"
+      stroke="#21C3D7"
+      stroke-width="17"
+    />
+  </g>
+  <g transform="rotate(-8 64 64)">
+    <ellipse cx="64" cy="64" rx="20" ry="28" fill="#FFFFFF" stroke="#0B2F4A" stroke-width="4" />
+    <path d="M48 64h32" stroke="#0B2F4A" stroke-width="4" stroke-linecap="round" />
+    <path d="M56 52v24" stroke="#21C3D7" stroke-width="4" stroke-linecap="round" />
+    <path d="M64 50v28" stroke="#21C3D7" stroke-width="4" stroke-linecap="round" />
+    <path d="M72 52v24" stroke="#21C3D7" stroke-width="4" stroke-linecap="round" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the light and dark logo SVGs with the new navy and teal swirl rugby ball mark

## Testing
- not run (asset-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2956de658832c83ad8430c04c89a0