### PR TITLE
Refactor empty states and update Turnstile branding

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
@@ -19,13 +19,13 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+          cache-dependency-path: the-turnstile-nextjs/package-lock.json
       - name: Run Security Audit
         run: npm audit --audit-level=high  # Fail if any high-severity vulnerabilities are detected
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
       - name: Build project
         run: npm run build
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+          cache-dependency-path: the-turnstile-nextjs/package-lock.json
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-staging.yml
+++ b/.github/workflows/firebase-hosting-staging.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
 
     steps:
       - name: Check out repository
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+          cache-dependency-path: the-turnstile-nextjs/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
 
     steps:
       - name: Check out repository
@@ -26,15 +26,15 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: the-scrum-book-nextjs/package-lock.json
+          cache-dependency-path: the-turnstile-nextjs/package-lock.json
 
       - name: Install dependencies
         run: npm ci
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
 
       - name: Build project
         run: npm run build
-        working-directory: the-scrum-book-nextjs
+        working-directory: the-turnstile-nextjs
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "the-turnstile",
-  "private": true,
-  "version": "0.0.0",
+  "private": true,
+  "version": "0.0.0",
   "scripts": {
     "dev": "cd the-turnstile-nextjs && npm run dev",
     "build": "cd the-turnstile-nextjs && npm run build",
     "start": "cd the-turnstile-nextjs && npm run start",
     "lint": "cd the-turnstile-nextjs && npm run lint",
-    "dev:server": "node server/index.js"
-  }
+    "dev:server": "node server/index.js"
+  }
 }

--- a/the-turnstile-nextjs/src/components/EmptyState.tsx
+++ b/the-turnstile-nextjs/src/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  message: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({ title, message }) => {
+  return (
+    <div className="text-center py-20 bg-surface rounded-md">
+      <h2 className="text-2xl font-bold text-text-strong">{title}</h2>
+      <p className="text-text-subtle mt-2">{message}</p>
+    </div>
+  );
+};

--- a/the-turnstile-nextjs/src/components/MatchList.tsx
+++ b/the-turnstile-nextjs/src/components/MatchList.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import type { Match } from '@/types';
 import { MatchListItem } from './MatchListItem';
 import { RefreshIcon, SearchIcon } from './Icons';
+import { EmptyState } from './EmptyState';
 
 interface MatchListProps {
   matches: Match[];
@@ -73,19 +74,17 @@ export const MatchList: React.FC<MatchListProps> = ({ matches, attendedMatchIds,
       </div>
 
       {showNoMatchesMessage && (
-        <div className="rounded-md bg-surface py-20 text-center text-text">
-          <h2 className="text-2xl font-bold text-text-strong">No Matches Scheduled</h2>
-          <p className="mt-2 text-text-subtle">There are no matches scheduled in the next 7 days.</p>
-        </div>
+        <EmptyState
+          title="No Matches Scheduled"
+          message="There are no matches scheduled in the next 7 days."
+        />
       )}
 
       {showNoResultsMessage && (
-        <div className="rounded-md bg-surface py-20 text-center text-text">
-          <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
-          <p className="mt-2 text-text-subtle">
-            No upcoming matches found for "{searchQuery}". Try a different search.
-          </p>
-        </div>
+        <EmptyState
+          title="No Matches Found"
+          message={`No upcoming matches found for "${searchQuery}". Try a different search.`}
+        />
       )}
 
       {!showNoMatchesMessage && !showNoResultsMessage && (

--- a/the-turnstile-nextjs/src/components/MyMatchesView.tsx
+++ b/the-turnstile-nextjs/src/components/MyMatchesView.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { PhotoUploadModal } from './PhotoUploadModal';
 import { PhotoViewerModal } from './PhotoViewerModal';
 import { formatDateUK } from '@/utils/date';
+import { EmptyState } from './EmptyState';
 
 interface MyMatchesViewProps {
     attendedMatches: AttendedMatch[];
@@ -82,10 +83,10 @@ export const MyMatchesView: React.FC<MyMatchesViewProps> = ({ attendedMatches, o
 
     if (attendedMatches.length === 0) {
         return (
-            <div className="text-center py-20 bg-surface rounded-md">
-                <h2 className="text-2xl font-bold text-text-strong">No Matches Attended Yet</h2>
-                <p className="text-text-subtle mt-2">Go to "Fixtures & Results" and click "I was there" to build your collection of attended games!</p>
-            </div>
+            <EmptyState
+                title="No Matches Attended Yet"
+                message='Go to "Fixtures & Results" and click "I was there" to build your collection of attended games!'
+            />
         );
     }
 
@@ -136,10 +137,10 @@ export const MyMatchesView: React.FC<MyMatchesViewProps> = ({ attendedMatches, o
             </div>
 
             {filteredAndSortedMatches.length === 0 ? (
-                 <div className="text-center py-20 bg-surface rounded-md">
-                    <h2 className="text-2xl font-bold text-text-strong">No Matches Found</h2>
-                    <p className="text-text-subtle mt-2">Try adjusting your filters to find the matches you're looking for.</p>
-                </div>
+                <EmptyState
+                    title="No Matches Found"
+                    message="Try adjusting your filters to find the matches you're looking for."
+                />
             ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {filteredAndSortedMatches.map((attendedMatch) => {

--- a/the-turnstile-nextjs/src/components/StatsView.tsx
+++ b/the-turnstile-nextjs/src/components/StatsView.tsx
@@ -81,7 +81,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
         if (!stats) return;
 
         const shareUrl = getAppShareUrl();
-        const shareText = `I've logged ${stats.totalMatches} matches, ${stats.totalGrounds} grounds and ${stats.totalPoints} total points this season on The Turnstile.`;
+        const shareText = 'Track every matchday with The Turnstile.';
 
         const outcome = await attemptShare({
             title: `${user.name}'s rugby league stats`,


### PR DESCRIPTION
## Summary
- add a reusable EmptyState component and refactor match views to use it for consistent messaging
- update the stats share copy to match the Turnstile rebrand
- point GitHub workflows at the the-turnstile-nextjs directory and tidy the root package.json formatting

## Testing
- npm run lint *(fails: next binary missing because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e354e673e0832c972057f43d9f72bc